### PR TITLE
feat(pi): add --file flag to cached-op.sh for plaintext key on Ubuntu…

### DIFF
--- a/docs/pi-deepseek.md
+++ b/docs/pi-deepseek.md
@@ -35,13 +35,29 @@ Use the native macOS Keychain to store the secret securely with zero plaintext f
    ```
    *(Note: The first time `pi` runs, macOS will ask you to approve terminal/application access to the Keychain item, which is a one-time prompt.)*
 
-### Option C: 1Password CLI (`op`)
-If you use 1Password to manage secrets:
+### Option C: 1Password CLI (`op`) with TTL Caching
+If you use 1Password to manage secrets, use the `cached-op.sh` wrapper to avoid hitting 1Password on every single API call:
 
 1. **Update your `models.json`**:
    ```json
-   "apiKey": "!op read op://private/deepseek-api-key/credential"
+   "apiKey": "!~/.pi/agent/cached-op.sh 'op://private/deepseek-api-key/credential' 4"
    ```
+   This caches the key for 4 hours (configurable). Subsequent calls within the TTL use the cache.
+
+### Option D: Plaintext File (Ubuntu Server, No 1Password CLI)
+For headless Ubuntu servers or environments where the 1Password CLI is not available, use a local plaintext file with the `--file` flag:
+
+1. **Create a plaintext key file**:
+   ```bash
+   mkdir -p ~/.cache/pi-op
+   echo "your-deepseek-api-key" > ~/.cache/pi-op/deepseek.key
+   chmod 600 ~/.cache/pi-op/deepseek.key
+   ```
+2. **Update your `models.json`**:
+   ```json
+   "apiKey": "!~/.pi/agent/cached-op.sh --file ~/.cache/pi-op/deepseek.key 4"
+   ```
+   The script reads the key from the file and caches it in memory for the TTL duration, just like the 1Password mode.
 
 ---
 

--- a/home-manager/config/pi/cached-op.sh
+++ b/home-manager/config/pi/cached-op.sh
@@ -1,17 +1,38 @@
 #!/usr/bin/env bash
-# cached-op.sh - wraps 'op read' with a TTL cache
-# Usage: cached-op.sh <op-path> [ttl-hours]
-# Example: cached-op.sh "op://private/deepseek-api-key/credential" 4
+# cached-op.sh - wraps 'op read' with a TTL cache, or reads from a plaintext file
+# Usage:
+#   cached-op.sh <op-path> [ttl-hours]                        # 1Password mode
+#   cached-op.sh --file <plaintext-file-path> [ttl-hours]     # plaintext file mode (Ubuntu server, no op CLI)
+# Examples:
+#   cached-op.sh "op://private/deepseek-api-key/credential" 4
+#   cached-op.sh --file ~/.cache/pi-op/deepseek.key 4
 
 set -euo pipefail
 
-OP_PATH="${1:?Usage: cached-op.sh <op-path> [ttl-hours]}"
-TTL_HOURS="${2:-4}"
+FILE_MODE=false
+OP_PATH=""
+FILE_PATH=""
+
+# Parse arguments
+if [[ "${1:-}" == "--file" ]]; then
+  FILE_MODE=true
+  FILE_PATH="${2:?Usage: cached-op.sh --file <plaintext-file-path> [ttl-hours]}"
+  TTL_HOURS="${3:-4}"
+else
+  OP_PATH="${1:?Usage: cached-op.sh <op-path> [ttl-hours]}"
+  TTL_HOURS="${2:-4}"
+fi
+
 CACHE_DIR="${HOME}/.cache/pi-op"
 mkdir -p "${CACHE_DIR}"
 
-# Use a hash of the op path as the cache key (avoid special chars in filenames)
-CACHE_KEY=$(echo -n "$OP_PATH" | shasum -a 256 | cut -d' ' -f1)
+# Use a hash of the source identifier as the cache key (avoid special chars in filenames)
+if $FILE_MODE; then
+  CACHE_SOURCE="file:${FILE_PATH}"
+else
+  CACHE_SOURCE="op:${OP_PATH}"
+fi
+CACHE_KEY=$(echo -n "$CACHE_SOURCE" | shasum -a 256 | cut -d' ' -f1)
 CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
 CACHE_TS="${CACHE_DIR}/${CACHE_KEY}.ts"
 
@@ -28,16 +49,34 @@ if [[ -f "${CACHE_FILE}" && -f "${CACHE_TS}" ]]; then
   fi
 fi
 
-# Fetch fresh value from 1Password
-if value=$(op read "${OP_PATH}" 2>/dev/null); then
-  echo "$value" >"${CACHE_FILE}"
-  echo "$now" >"${CACHE_TS}"
-  echo "$value"
-else
-  if [[ -f "${CACHE_FILE}" ]]; then
-    cat "${CACHE_FILE}"
-    exit 0
+# Fetch fresh value
+if $FILE_MODE; then
+  # Read from plaintext file (e.g., Ubuntu server without 1Password CLI)
+  if [[ -f "${FILE_PATH}" ]]; then
+    value=$(cat "${FILE_PATH}")
+    echo "$value" >"${CACHE_FILE}"
+    echo "$now" >"${CACHE_TS}"
+    echo "$value"
+  else
+    if [[ -f "${CACHE_FILE}" ]]; then
+      cat "${CACHE_FILE}"
+      exit 0
+    fi
+    echo "Error: Plaintext file '${FILE_PATH}' not found and no cached value available" >&2
+    exit 1
   fi
-  echo "Error: Failed to read from 1Password and no cached value available" >&2
-  exit 1
+else
+  # Fetch from 1Password
+  if value=$(op read "${OP_PATH}" 2>/dev/null); then
+    echo "$value" >"${CACHE_FILE}"
+    echo "$now" >"${CACHE_TS}"
+    echo "$value"
+  else
+    if [[ -f "${CACHE_FILE}" ]]; then
+      cat "${CACHE_FILE}"
+      exit 0
+    fi
+    echo "Error: Failed to read from 1Password and no cached value available" >&2
+    exit 1
+  fi
 fi

--- a/home-manager/config/pi/cached-op.sh
+++ b/home-manager/config/pi/cached-op.sh
@@ -13,7 +13,6 @@ FILE_MODE=false
 OP_PATH=""
 FILE_PATH=""
 
-# Parse arguments
 if [[ "${1:-}" == "--file" ]]; then
   FILE_MODE=true
   FILE_PATH="${2:?Usage: cached-op.sh --file <plaintext-file-path> [ttl-hours]}"
@@ -26,37 +25,35 @@ fi
 CACHE_DIR="${HOME}/.cache/pi-op"
 mkdir -p "${CACHE_DIR}"
 
-# Use a hash of the source identifier as the cache key (avoid special chars in filenames)
-if $FILE_MODE; then
+if ${FILE_MODE}; then
   CACHE_SOURCE="file:${FILE_PATH}"
 else
   CACHE_SOURCE="op:${OP_PATH}"
 fi
-CACHE_KEY=$(echo -n "$CACHE_SOURCE" | shasum -a 256 | cut -d' ' -f1)
+CACHE_KEY=$(echo -n "${CACHE_SOURCE}" | shasum -a 256 | cut -d' ' -f1)
 CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
 CACHE_TS="${CACHE_DIR}/${CACHE_KEY}.ts"
 
 now=$(date +%s)
-ttl_seconds=$((TTL_HOURS * 3600))
+ttl_seconds=$((${TTL_HOURS} * 3600))
 
-# Return cached value if still valid
 if [[ -f "${CACHE_FILE}" && -f "${CACHE_TS}" ]]; then
   cached_ts=$(cat "${CACHE_TS}")
-  age=$((now - cached_ts))
-  if [[ $age -lt $ttl_seconds ]]; then
+  age=$((${now} - ${cached_ts}))
+  if [[ ${age} -lt ${ttl_seconds} ]]; then
     cat "${CACHE_FILE}"
     exit 0
   fi
 fi
 
 # Fetch fresh value
-if $FILE_MODE; then
+if ${FILE_MODE}; then
   # Read from plaintext file (e.g., Ubuntu server without 1Password CLI)
   if [[ -f "${FILE_PATH}" ]]; then
     value=$(cat "${FILE_PATH}")
-    echo "$value" >"${CACHE_FILE}"
-    echo "$now" >"${CACHE_TS}"
-    echo "$value"
+    echo "${value}" >"${CACHE_FILE}"
+    echo "${now}" >"${CACHE_TS}"
+    echo "${value}"
   else
     if [[ -f "${CACHE_FILE}" ]]; then
       cat "${CACHE_FILE}"
@@ -68,9 +65,9 @@ if $FILE_MODE; then
 else
   # Fetch from 1Password
   if value=$(op read "${OP_PATH}" 2>/dev/null); then
-    echo "$value" >"${CACHE_FILE}"
-    echo "$now" >"${CACHE_TS}"
-    echo "$value"
+    echo "${value}" >"${CACHE_FILE}"
+    echo "${now}" >"${CACHE_TS}"
+    echo "${value}"
   else
     if [[ -f "${CACHE_FILE}" ]]; then
       cat "${CACHE_FILE}"


### PR DESCRIPTION
… servers

Support environments without 1Password CLI by reading the API key from a plaintext file (~/.cache/pi-op/deepseek.key) via the --file flag. Same TTL caching applies in both 1Password and file modes.