### PR TITLE
feat(pi): add AGENTS.md repo memory and optimize spec workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# nix-config Architecture
+
+Home Manager configuration for macOS (MacBook Pro, aarch64-darwin) and Ubuntu/NixOS (x86_64-linux) machines.
+
+## Directory Structure
+
+```
+.
+├── flake.nix                 # Entry point: inputs, mkHomeConfig, homeConfigurations, devShells
+├── flake.lock
+├── shell.nix                 # Dev shell (direnv-managed)
+├── justfile                  # Task runner: switch, check, fix, update, gc
+├── nix.conf                  # Nix daemon config
+├── home-manager/
+│   ├── home.nix              # Main HM config: programs, nix-index, llm-agents, pi-agent
+│   ├── modules/
+│   │   ├── core/             # dev.nix, cli.nix, gui.nix, font.nix, nix.nix, dev-php.nix, dev-llm.nix, dev-db.nix, dev-ops.nix, dev-terraform.nix
+│   │   ├── programs/         # git.nix, tmux.nix, fzf.nix, ssh.nix, 1password.nix, common.nix, pi.nix
+│   │   └── shell/            # bash.nix, function.sh, inputrc, prompt configs
+│   └── config/               # Raw configs: .npmrc, iterm2.json, kube_config.age, pi/
+├── hosts/                    # Host-specific notes (README.md)
+├── secrets/
+│   ├── secrets.nix           # Agenix decryption mapping
+│   ├── deepseek.age
+│   └── README.md
+├── bin/                      # bootstrap.sh, check-eval.sh
+└── docs/                     # macOS.md, ubuntu.md, edge.md, dev-env.md, NixOS.md, pi-deepseek.md, bookmarks.md
+```
+
+## Key Dependencies (flake inputs)
+
+- `nixpkgs` → `nixos-25.05` (stable)
+- `nixpkgs-unstable` → `nixos-unstable` (for bleeding-edge packages)
+- `home-manager` → `release-25.05`
+- `agenix` — secret encryption/decryption
+- `nix-index-database` — command-not-found lookup
+- `llm-agents` (numtide/llm-agents.nix) — LLM agent packages
+
+## Hosts
+
+| Host output name | System | User | GUI |
+|---|---|---|---|
+| `quang.van.nguyen@Nguyens-MacBook-Pro.local` | aarch64-darwin | quang.van.nguyen | yes |
+| `xluffy-zzbot@elbaf-sky-n100` | x86_64-linux | xluffy-zzbot | no |
+
+Each host has custom `extraSpecialArgs`: `pkgs-unstable`, `llm-agents`, `agenix-cli`, `hasGUI`.
+
+## Common Commands
+
+```bash
+just switch   # Apply HM config (reads $HM_FLAKE_ATTR from .envrc.local)
+just check    # Validate eval
+just fix      # alejandra format + deadnix + statix
+just update   # Update nixpkgs-unstable flake input
+just gc       # Garbage collect profiles older than 2 days
+```
+
+## Pi-Agent Configuration
+
+Managed via `home-manager/modules/programs/pi.nix` and `home-manager/config/pi/`:
+- `settings.json` — pi settings
+- `models.json` — custom model definitions
+- `cached-op.sh` — cached operation helper
+
+Prompt templates live in `.pi/agent/prompts/` (managed by HM as symlinks to nix store).
+
+## Secrets
+
+Encrypted with `agenix`. Host SSH keys are used for decryption. `secrets.nix` maps secret files to host public keys.
+
+## Coding Conventions
+
+- Nix formatting: alejandra
+- Dead code removal: deadnix
+- Static analysis: statix
+- All changes go through `just check` before `just switch`
+- Host-specific overrides use `extraModules` in `flake.nix`, not inline conditionals

--- a/README.md
+++ b/README.md
@@ -27,27 +27,6 @@ They'll be available whenever you run `nix develop` or `nix-shell`.
 > openssl version -a
 ```
 
-## devenv
-
-```bash
-> devenv init
-
-> cat devenv.nix
-{ pkgs, ... }:
-
-{
-  packages = [
-    # pkgs.openssl_1_1
-  ];
-
-  languages.python.enable = true;
-  languages.python.version = "3.9.21";
-  languages.python.venv.enable = true;
-  languages.python.poetry.enable = true;
-  languages.python.poetry.install.enable = true;
-}
-```
-
 ## Specific package version
 
 ```nix

--- a/home-manager/config/pi/prompts/spec-workflow.md
+++ b/home-manager/config/pi/prompts/spec-workflow.md
@@ -9,6 +9,18 @@ Follow this disciplined, spec-driven workflow. Do NOT skip steps or jump ahead.
 
 ---
 
+## Prerequisite: Load Repo Context (do NOT re-scan)
+
+Before doing any research, check if the project has an architecture document:
+
+1. Read `AGENTS.md` in the project root (it's already in your context).
+2. If it doesn't exist or is stale, read `CLAUDE.md`, `.cursor/rules/`, or any `docs/architecture*.md`.
+3. Only if none of these exist, do a lightweight scan: `ls` the top-level + one level deep. Do NOT recursively read every file.
+
+**Key principle**: The `AGENTS.md` file is the cached repo memory. Trust it. Don't re-scan what's already documented.
+
+---
+
 ## File Naming Convention
 
 All documents live under `~/code/me/spec/YYYY-MM-DD/` where `YYYY-MM-DD` is today's date (infer from context or ask if unsure). If there are multiple spec/impl files in the directory, number them sequentially to keep them organized more easily.
@@ -163,3 +175,4 @@ For each phase, in order:
 - **Ask, don't assume**: If something is ambiguous mid-implementation, pause and ask.
 - **Senior-level quality**: Error handling, logging, edge cases, and clean code are non-negotiable.
 - **DevOps mindset**: Consider deployment, CI/CD, monitoring, and operability from the start.
+- **Update AGENTS.md**: After completing the implementation, suggest additions/updates to `AGENTS.md` if new patterns, modules, or architecture decisions were introduced. This keeps the cached repo memory fresh for future sessions.


### PR DESCRIPTION
- Add AGENTS.md with full repo architecture as cached context for pi-agent
- Update spec-workflow template to read AGENTS.md first before scanning
- Add ground rule to keep AGENTS.md updated after implementation
- Remove stale devenv section from README