### PR TITLE
feat(pi): multi-provider support with auto directory switching

### DIFF
--- a/docs/pi.md
+++ b/docs/pi.md
@@ -1,0 +1,100 @@
+# Pi Coding Agent
+
+Multi-provider setup with automatic provider selection by directory. All configs managed via Home Manager (`home-manager/config/pi/`).
+
+## How it works
+
+Running `pi` in a directory auto-selects the provider:
+
+| Directory | Provider | Model |
+|---|---|---|
+| `~/code/me/*` | DeepSeek | `deepseek-chat` |
+| `~/code/work/*` | Anthropic | `claude-sonnet-4-20250514` |
+| Anywhere else | `settings.json` default | DeepSeek |
+
+Override with flags: `pi --provider openai --model gpt-4o`.
+
+The magic is a shell wrapper in `function.sh`:
+
+```bash
+pi() {
+  case "$PWD" in
+    "$HOME/code/me"*)   command pi --provider deepseek --model deepseek-chat "$@";;
+    "$HOME/code/work"*) command pi --provider anthropic --model claude-sonnet-4-20250514 "$@";;
+    *)                  command pi "$@";;
+  esac
+}
+```
+
+## Providers
+
+Two kinds:
+
+| Type | Config file | Example |
+|---|---|---|
+| **Custom** — pi doesn't ship with it | `models.json` | DeepSeek, Ollama, OpenRouter |
+| **Built-in** — pi knows all its models | `auth.json` | Anthropic, OpenAI, Gemini, Mistral, Groq |
+
+Both pull API keys from 1Password via `cached-op.sh`, which caches keys for the day under `~/.cache/pi-op/`. No secrets in nix-config.
+
+## Switching models at runtime
+
+- **`/model`** — open model picker (any provider/model)
+- **`Ctrl+P`** — cycle through `enabledModels` (defined in `settings.json`)
+- **`Ctrl+T`** — cycle thinking level (off → minimal → low → medium → high → xhigh)
+
+Currently in the cycle: `deepseek-*`, `claude-sonnet-*`, `claude-opus-*`.
+
+## Adding a provider
+
+### Built-in (OpenAI, Gemini, etc.)
+
+1. Store key in 1Password: `op://private/openai-api-key/credential`
+2. Add to `home-manager/config/pi/auth.json`:
+   ```json
+   "openai": {
+     "type": "api_key",
+     "key": "!~/.pi/agent/cached-op.sh 'op://private/openai-api-key/credential'"
+   }
+   ```
+3. Optionally add to `enabledModels` in `settings.json` and add a directory rule in `function.sh`.
+4. `just switch`
+
+### Custom (Ollama, OpenRouter, company proxy, etc.)
+
+1. Add to `home-manager/config/pi/models.json`:
+   ```json
+   "openrouter": {
+     "baseUrl": "https://openrouter.ai/api/v1",
+     "api": "openai-completions",
+     "apiKey": "!~/.pi/agent/cached-op.sh 'op://private/openrouter-api-key/credential'",
+     "models": [{ "id": "openrouter/anthropic/claude-sonnet-4", "name": "..." }]
+   }
+   ```
+2. `just switch`
+
+### Per-project override
+
+Create `.pi/settings.json` in a project root (not managed by nix-config):
+
+```json
+{ "defaultProvider": "openai", "defaultModel": "gpt-4o" }
+```
+
+## Useful commands
+
+```bash
+pi                        # new session
+pi --resume               # resume last session
+pi --resume -n 2          # resume 2nd most recent
+pi --list-sessions        # list all sessions
+pi --thinking off         # disable thinking
+```
+
+In-session: `/tree` (branches), `/new`, `/fork`, `/compact`, `/review`, `/git-ci`, `/skill:<name>`.
+
+## Troubleshooting
+
+- **No API key:** verify 1Password path with `op read 'op://...'`; clear cache `rm -rf ~/.cache/pi-op/`
+- **Wrapper not active:** `type pi` should show "function"; new terminal or `source ~/.config/nix-config/function.sh`
+- **Bypass wrapper:** `command pi` runs pi directly

--- a/home-manager/config/pi/auth.json
+++ b/home-manager/config/pi/auth.json
@@ -1,0 +1,6 @@
+{
+  "anthropic": {
+    "type": "api_key",
+    "key": "!~/.pi/agent/cached-op.sh 'op://private/anthropic-api-key/credential'"
+  }
+}

--- a/home-manager/config/pi/cached-op.sh
+++ b/home-manager/config/pi/cached-op.sh
@@ -11,7 +11,10 @@ OP_PATH="${1:?Usage: cached-op.sh <op-path>}"
 
 CACHE_DIR="${HOME}/.cache/pi-op"
 mkdir -p "${CACHE_DIR}"
-FILE_PATH="${CACHE_DIR}/deepseek.key"
+
+# Derive a unique filename from the OP_PATH hash (supports multiple keys)
+KEY_NAME=$(echo -n "${OP_PATH}" | shasum -a 256 | cut -d' ' -f1 | head -c 12)
+FILE_PATH="${CACHE_DIR}/${KEY_NAME}.key"
 
 DATE=$(date +"%Y-%m-%d")
 CACHE_KEY=$(echo -n "${DATE}" | shasum -a 256 | cut -d' ' -f1)

--- a/home-manager/config/pi/settings.json
+++ b/home-manager/config/pi/settings.json
@@ -3,7 +3,9 @@
   "defaultModel": "deepseek-chat",
   "defaultThinkingLevel": "high",
   "enabledModels": [
-    "deepseek-*"
+    "deepseek-*",
+    "claude-sonnet-*",
+    "claude-opus-*"
   ],
   "theme": "dark",
   "enableInstallTelemetry": false,

--- a/home-manager/modules/programs/pi.nix
+++ b/home-manager/modules/programs/pi.nix
@@ -2,6 +2,7 @@ _: {
   home.file = {
     ".pi/agent/settings.json".source = ../../config/pi/settings.json;
     ".pi/agent/models.json".source = ../../config/pi/models.json;
+    ".pi/agent/auth.json".source = ../../config/pi/auth.json;
     ".pi/agent/cached-op.sh" = {
       source = ../../config/pi/cached-op.sh;
       executable = true;

--- a/home-manager/modules/shell/function.sh
+++ b/home-manager/modules/shell/function.sh
@@ -85,6 +85,28 @@ bz() {
   fi
 }
 
+pi() {
+  local provider=""
+  local model=""
+
+  case "$PWD" in
+  "$HOME/code/me"*)
+    provider="deepseek"
+    model="deepseek-chat"
+    ;;
+  "$HOME/code/work"*)
+    provider="anthropic"
+    model="claude-sonnet-4-20250514"
+    ;;
+  esac
+
+  if [[ -n "$provider" ]]; then
+    command pi --provider "$provider" --model "$model" "$@"
+  else
+    command pi "$@"
+  fi
+}
+
 f() {
   commit_msg=$(git diff --cached | llm -m 4o-mini "$(cat ~/.config/nix-config/commit-prompt.txt)")
   printf "Commit message:\n %s \n" "${commit_msg}"


### PR DESCRIPTION
- Add Anthropic auth.json via 1Password cached-op.sh
- Make cached-op.sh multi-key aware with hash-based filenames
- Add pi() shell wrapper for auto-provider by directory (code/me vs code/work)
- Add Claude models to enabledModels cycle
- Add docs/pi.md covering setup, provider types, and usage