### PR TITLE
feat(pi): clean up stale daily cache files in cached-op.sh

### DIFF
--- a/home-manager/config/pi/cached-op.sh
+++ b/home-manager/config/pi/cached-op.sh
@@ -5,7 +5,7 @@
 # Examples:
 #   cached-op.sh "op://private/deepseek-api-key/credential"
 
-set -euo pipefail
+set -uo pipefail
 
 OP_PATH="${1:?Usage: cached-op.sh <op-path>}"
 
@@ -13,20 +13,27 @@ CACHE_DIR="${HOME}/.cache/pi-op"
 mkdir -p "${CACHE_DIR}"
 FILE_PATH="${CACHE_DIR}/deepseek.key"
 
-DATE=$(date +"%Y-%m-%d")
+printf -v DATE '%(%Y-%m-%d)T' -1
 CACHE_KEY=$(echo -n "${DATE}" | shasum -a 256 | cut -d' ' -f1)
 CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
 
 _log() {
-  printf "\x1B[2;32m"
-  echo "[LOG]" "[$(date +'%Y-%m-%d %H:%M:%S')]:" "$*"
-  printf "\x1B[0m"
+  printf '\x1B[2;32m[LOG] [%(%Y-%m-%d %H:%M:%S)T]: %s\x1B[0m\n' -1 "$*"
 }
 
 _die() {
-  printf "\x1B[2;31m"
-  echo "[ERROR]" "[$(date +'%Y-%m-%d %H:%M:%S')]:" "$*" >&2
+  printf '\x1B[2;31m[ERROR] [%(%Y-%m-%d %H:%M:%S)T]: %s\x1B[0m\n' -1 "$*" >&2
   exit 1
+}
+
+_cleanup_old_cache() {
+  local file
+  for file in "${CACHE_DIR}"/*; do
+    [[ "${file}" == "${CACHE_FILE}" ]] && continue
+    [[ "${file}" == "${FILE_PATH}" ]] && continue
+    [[ -f "${file}" ]] || continue
+    rm -f "${file}"
+  done
 }
 
 _load_cache_file() {
@@ -41,15 +48,15 @@ main() {
 
   if [[ -f ${FILE_PATH} ]]; then
     value=$(cat "${FILE_PATH}")
-    echo "${value}" >"${CACHE_FILE}"
-    _load_cache_file
   elif value=$(op read "${OP_PATH}" 2>/dev/null); then
-    echo "${value}" >"${CACHE_FILE}"
-    _load_cache_file
+    :
   else
-    echo "Error: Plaintext file '${FILE_PATH}' not found and no cached value available" >&2
-    exit 1
+    _die "Plaintext file '${FILE_PATH}' not found and no cached value available"
   fi
+
+  printf '%s' "${value}" >"${CACHE_FILE}"
+  _cleanup_old_cache
+  _load_cache_file
 }
 
 main "$@"

--- a/home-manager/config/pi/skills/bash-scripting/SKILL.md
+++ b/home-manager/config/pi/skills/bash-scripting/SKILL.md
@@ -677,7 +677,7 @@ Every script starts with a header block:
 
 ### Function or Implementation Comments
 
-Less comments, code is documentation, no need explain again. I prefer not to use comments before lines of code. In general, no comments is better.
+**Never** use comments inside or above functions, methods, or any line of code. Code must be self-documenting — clear function names, well-scoped locals, and single-responsibility functions remove the need for explanatory comments. No block comments above `main()`, helper functions, or any function definition. No inline comments explaining what a line does.
 
 ### TODO Comments
 

--- a/tests/cached-op.bats
+++ b/tests/cached-op.bats
@@ -131,6 +131,43 @@ clear_cache() {
   [[ "${output}" =~ "Usage" ]]
 }
 
+@test "cleanup — old cache files removed, plaintext fallback preserved" {
+  clear_cache
+  mkdir -p "${CACHE_DIR}"
+
+  # Seed two old cache files from different previous days
+  local day1 day2 old_key1 old_key2
+  day1="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)"
+  day2="$(date -v-3d +%Y-%m-%d 2>/dev/null || date -d '3 days ago' +%Y-%m-%d)"
+  old_key1="$(echo -n "${day1}" | shasum -a 256 | cut -d' ' -f1)"
+  old_key2="$(echo -n "${day2}" | shasum -a 256 | cut -d' ' -f1)"
+  printf '%s' "stale-secret-1" >"${CACHE_DIR}/${old_key1}"
+  printf '%s' "stale-secret-2" >"${CACHE_DIR}/${old_key2}"
+
+  # Plaintext fallback should be preserved after cleanup
+  printf '%s' "persistent-secret" >"${CACHE_DIR}/deepseek.key"
+
+  local file_count_before
+  file_count_before="$(find "${CACHE_DIR}" -type f | wc -l | tr -d ' ')"
+  (( file_count_before == 3 ))
+
+  run bash "${SCRIPT}" "op://private/test-key/credential"
+
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" == "persistent-secret" ]]
+
+  # Only today's cache file + deepseek.key should remain
+  local today cache_key
+  printf -v today '%(%Y-%m-%d)T' -1
+  cache_key="$(echo -n "${today}" | shasum -a 256 | cut -d' ' -f1)"
+  [[ -f "${CACHE_DIR}/${cache_key}" ]]
+  [[ -f "${CACHE_DIR}/deepseek.key" ]]
+
+  local file_count_after
+  file_count_after="$(find "${CACHE_DIR}" -type f | wc -l | tr -d ' ')"
+  (( file_count_after == 2 ))
+}
+
 @test "plaintext file with leading/trailing whitespace" {
   clear_cache
   mkdir -p "${CACHE_DIR}"


### PR DESCRIPTION
- Add _cleanup_old_cache() to remove expired cache entries while preserving the plaintext fallback
- Switch to printf builtin for timestamps and value output, removing date/echo subshells
- Remove set -e in favor of explicit error handling
- Consolidate cache write and cleanup into a single code path in main()
- Strengthen bash-scripting skill: forbid all explanatory comments inside or above functions
- Add bats test verifying old cache removal and deepseek.key preservation