### PR TITLE
feat(atuin): add home-manager module and troubleshooting docs

### DIFF
--- a/docs/atuin.md
+++ b/docs/atuin.md
@@ -172,3 +172,17 @@ Make sure you imported history: `atuin import bash`. Check the DB: `atuin stats`
 
 **SCP'd DB doesn't show new entries?**
 Atuin caches the DB in memory. `exec bash` to reload, or just start typing — `Ctrl-R` reopens the TUI with fresh data.
+
+**Tab to edit does not work (empties the command line)?**
+This occurs on macOS if you are using the system default `/bin/bash` which is **version 3.2.57** (released in 2006). Atuin's command injection relies on `READLINE_LINE` and `READLINE_POINT` variables, which are only supported in **Bash 4.0+**. 
+To fix this, permanently change your default login shell to the Nix-installed Bash 5.2+:
+1. Whitelist the Nix Bash binary path:
+   ```bash
+   echo "$HOME/.nix-profile/bin/bash" | sudo tee -a /etc/shells
+   ```
+2. Change your default login shell:
+   ```bash
+   chsh -s "$HOME/.nix-profile/bin/bash"
+   ```
+3. Open a new terminal tab/window and verify with `echo $BASH_VERSION`.
+

--- a/home-manager/modules/programs/default.nix
+++ b/home-manager/modules/programs/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./common.nix
     ./1password.nix
+    ./atuin.nix
     ./fzf.nix
     ./git.nix
     ./ssh.nix


### PR DESCRIPTION
### Summary

- Import atuin.nix in programs module
- Document macOS Tab-to-edit fix for Bash 3.2 vs 5.2+ in atuin docs

### Details

- Added `home-manager/modules/programs/atuin.nix` to the programs default import list
- Added troubleshooting section in `docs/atuin.md` explaining why Tab-to-edit fails on macOS (system Bash 3.2.57) and how to switch to Nix-installed Bash 5.2+