### PR TITLE
fix: replace em dashes with hyphens for consistent formatting

### DIFF
--- a/home-manager/config/pi/APPEND_SYSTEM.md
+++ b/home-manager/config/pi/APPEND_SYSTEM.md
@@ -1,0 +1,1 @@
+Always use hyphens (-) instead of em dashes (—) in all output. Never emit the em dash character (U+2014).

--- a/home-manager/config/pi/README.md
+++ b/home-manager/config/pi/README.md
@@ -4,11 +4,11 @@ Personal pi coding agent setup. Minimal, intentional, software-engineering focus
 
 ## Philosophy
 
-- **KISS** — Keep it simple. No bloat, no magic, no fancy abstractions.
-- **Prompts over skills** — Custom prompt templates are the primary interface. Skills are only for narrow, repeatable domain knowledge (nix, bash, laravel).
-- **No internet copy-paste** — Every skill, prompt, and extension here is hand-written for real workflows. Zero cloned "awesome" lists or viral dotfiles.
-- **Software engineering focus** — Spec-driven development, code review, git workflows. Not a general-purpose chatbot.
-- **Minimal extensions** — One custom provider (`company-provider.ts`). That's it.
+- **KISS** - Keep it simple. No bloat, no magic, no fancy abstractions.
+- **Prompts over skills** - Custom prompt templates are the primary interface. Skills are only for narrow, repeatable domain knowledge (nix, bash, laravel).
+- **No internet copy-paste** - Every skill, prompt, and extension here is hand-written for real workflows. Zero cloned "awesome" lists or viral dotfiles.
+- **Software engineering focus** - Spec-driven development, code review, git workflows. Not a general-purpose chatbot.
+- **Minimal extensions** - One custom provider (`company-provider.ts`). That's it.
 
 ## Structure
 
@@ -36,5 +36,5 @@ pi/
 
 1. No new skill unless it solves a **recurring, narrow, well-defined** problem.
 2. New prompts must stay under 200 lines. If it's longer, split it or simplify.
-3. No third-party extensions — if it's not in this repo, it's not needed.
+3. No third-party extensions - if it's not in this repo, it's not needed.
 4. All changes go through `just check` before `just switch`.

--- a/home-manager/config/pi/prompts/git-ci.md
+++ b/home-manager/config/pi/prompts/git-ci.md
@@ -9,7 +9,7 @@ Rules for the commit message:
 - The first line should be a short summary of the changes, without emojis, must be 72 characters or fewer
 - Choose the correct type: feat, fix, docs, style, refactor, test, chore
 - Use bullet points for multiple changes
-- If there are no changes, or the input is blank — return a blank string
+- If there are no changes, or the input is blank - return a blank string
 
 Commit Types
 

--- a/home-manager/config/pi/prompts/review.md
+++ b/home-manager/config/pi/prompts/review.md
@@ -4,9 +4,9 @@ adapted-from: https://github.com/openai/codex/blob/963009737fc6e7d45ca5cb37d6310
 preferred-models: ["deepseek-v4-pro", "mimo-v2.5-pro", "gpt-5.1", "gemini-2.5-pro"]
 ---
 
-You are a senior, full-stack software engineer conducting a code review for code changes made by another engineer. The author may be a junior engineer or someone from a different discipline (frontend, backend, DevOps, data, etc.) — approach the review with patience and an instructive tone. Focus on knowledge transfer: explain *why* something is a problem, not just *what* is wrong.
+You are a senior, full-stack software engineer conducting a code review for code changes made by another engineer. The author may be a junior engineer or someone from a different discipline (frontend, backend, DevOps, data, etc.) - approach the review with patience and an instructive tone. Focus on knowledge transfer: explain *why* something is a problem, not just *what* is wrong.
 
-**You are likely a different model than the one that wrote the code.** This is intentional — use your fresh, independent perspective to catch issues the coding model may have missed. Different models have different blind spots, reasoning styles, and strengths. Lean into what *your* model family is good at (e.g., thoroughness, security awareness, edge-case analysis, clarity of explanation). If you notice patterns or mistakes that are characteristic of a particular model's style, call them out constructively.
+**You are likely a different model than the one that wrote the code.** This is intentional - use your fresh, independent perspective to catch issues the coding model may have missed. Different models have different blind spots, reasoning styles, and strengths. Lean into what *your* model family is good at (e.g., thoroughness, security awareness, edge-case analysis, clarity of explanation). If you notice patterns or mistakes that are characteristic of a particular model's style, call them out constructively.
 
 Review the staged changes from `git diff --cached`.
 
@@ -20,13 +20,13 @@ Only flag an issue when all of these hold:
 4. The bug was introduced in the staged changes (do not flag pre-existing bugs).
 5. The original author would likely fix it if they were made aware of it.
 6. The bug does not rely on unstated assumptions about the codebase or author's intent.
-7. You must identify specific, provably affected parts of the code — speculation is not enough.
+7. You must identify specific, provably affected parts of the code - speculation is not enough.
 8. The issue is clearly not an intentional change by the original author.
 
 ## Comment guidelines
 
 1. The comment should make it clear *why* the issue is a bug.
-2. The comment should accurately communicate severity — don't exaggerate or downplay.
+2. The comment should accurately communicate severity - don't exaggerate or downplay.
 3. Be brief: at most one paragraph. No line breaks within the natural language flow unless necessary for a code fragment.
 4. Code chunks should be ≤ 3 lines and wrapped in inline code tags or a code block.
 5. Clearly state the scenarios, environments, or inputs necessary for the bug to arise.
@@ -39,7 +39,7 @@ Only flag an issue when all of these hold:
 Use ```suggestion blocks ONLY for concrete replacement code:
 - Preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).
 - Do NOT introduce or remove outer indentation levels unless that is the actual fix.
-- Keep the suggestion minimal — no commentary inside the block.
+- Keep the suggestion minimal - no commentary inside the block.
 
 ## Priority levels
 

--- a/home-manager/config/pi/prompts/spec-quick.md
+++ b/home-manager/config/pi/prompts/spec-quick.md
@@ -5,7 +5,7 @@ You are a Senior Software Engineer and Senior DevOps Engineer. Your task is:
 
 $ARGUMENTS
 
-Follow this lightweight workflow for small-scope tasks (bug fixes, minor features, refactors, config changes). Do NOT skip to code immediately — think first, then act.
+Follow this lightweight workflow for small-scope tasks (bug fixes, minor features, refactors, config changes). Do NOT skip to code immediately - think first, then act.
 
 ---
 
@@ -68,10 +68,10 @@ If `$ARGUMENTS` contains any external references (GitHub URLs, repo links, libra
 
 Before writing anything, briefly:
 
-1. **Restate the task** in your own words — confirm you understand the problem.
-2. **Identify the scope boundary** — what is this touching and, more importantly, what is it NOT touching?
-3. **Check for existing solutions** — is there already code/pattern in the repo that handles this? Avoid reinventing.
-4. **Flag any ambiguity** — if anything is unclear, ask me before proceeding.
+1. **Restate the task** in your own words - confirm you understand the problem.
+2. **Identify the scope boundary** - what is this touching and, more importantly, what is it NOT touching?
+3. **Check for existing solutions** - is there already code/pattern in the repo that handles this? Avoid reinventing.
+4. **Flag any ambiguity** - if anything is unclear, ask me before proceeding.
 
 Keep this as a bullet-point summary in chat. Do NOT create a file yet.
 
@@ -126,19 +126,19 @@ Present the task plan to me for a quick sanity check. I will confirm or ask for 
 
 Once the plan is confirmed:
 
-1. **Implement**: Write the code, tests, configuration — everything the task requires.
+1. **Implement**: Write the code, tests, configuration - everything the task requires.
 2. **Requirements Checkpoint** 🔴: Before moving to verification, pause and re-read the task plan (`task-<title>.md`). Cross-check every line of code you just wrote against:
-   - **Scope boundary** — did you touch anything out of scope?
-   - **Approach** — did you follow the agreed plan, or did you drift?
-   - **Edge cases** — are all listed edge cases handled explicitly?
-   - **Existing patterns** — did you match the repo's conventions, or did you invent new ones?
+   - **Scope boundary** - did you touch anything out of scope?
+   - **Approach** - did you follow the agreed plan, or did you drift?
+   - **Edge cases** - are all listed edge cases handled explicitly?
+   - **Existing patterns** - did you match the repo's conventions, or did you invent new ones?
    
    **If anything doesn't match, fix it NOW before verifying.** Do not proceed with broken alignment.
 3. **Verify**: Run the verification steps. Show me the evidence (test output, CLI output, etc.).
 4. **Review**: Present the completed work. Ask:
    - Does this match your expectations?
    - Any edge cases I missed?
-5. **Git Checkpoint** 🔴 (MANDATORY — this is your rollback safety net):
+5. **Git Checkpoint** 🔴 (MANDATORY - this is your rollback safety net):
    - After I confirm the review, invoke the **git-ci** prompt template to:
      1. Stage all changes (`git add`)
      2. Generate a commit message and branch name

--- a/home-manager/config/pi/prompts/spec-workflow.md
+++ b/home-manager/config/pi/prompts/spec-workflow.md
@@ -161,7 +161,7 @@ Format:
 
 ## Phase 1: [Name]
 
-- **Objective**: A clear, testable outcome this phase must achieve. Must be verifiable — if you can't write a test for it, it's not specific enough.
+- **Objective**: A clear, testable outcome this phase must achieve. Must be verifiable - if you can't write a test for it, it's not specific enough.
 - **Goal**: What this phase delivers
 - **Depends on**: Nothing / Phase 0 research
 - **Verification**: How to confirm this phase is done correctly (tests, assertions, manual checks). Every verification step must trace back to the objective above.
@@ -184,13 +184,13 @@ Present the implementation plan for review. Do NOT proceed until I approve it.
 For each phase, in order:
 
 1. **Announce**: State which phase you're starting and what it depends on.
-2. **Implement**: Write the code, tests, configuration — everything the phase requires.
+2. **Implement**: Write the code, tests, configuration - everything the phase requires.
 3. **Requirements Checkpoint** 🔴: Before verifying, pause and re-read the spec (`spec-<title>.md`) and implementation plan (`impl-<title>.md`) for this phase. Cross-check every line of code you wrote against:
-   - **FRs (Functional Requirements)** — is each FR satisfied by this phase's code?
-   - **NFRs (Non-Functional Requirements)** — are performance, security, observability constraints met?
-   - **Phase objective** — does the code achieve exactly what this phase's objective states, nothing more, nothing less?
-   - **Edge cases** — are all edge cases from the spec handled in this phase's code?
-   - **Repo conventions** — did you match existing patterns, or did you introduce a new style?
+   - **FRs (Functional Requirements)** - is each FR satisfied by this phase's code?
+   - **NFRs (Non-Functional Requirements)** - are performance, security, observability constraints met?
+   - **Phase objective** - does the code achieve exactly what this phase's objective states, nothing more, nothing less?
+   - **Edge cases** - are all edge cases from the spec handled in this phase's code?
+   - **Repo conventions** - did you match existing patterns, or did you introduce a new style?
    
    **If anything doesn't match, fix it NOW before verifying.** Do not proceed with a broken traceability chain from spec → impl → code.
 4. **Verify**: Run the verification steps against the phase's **Objective**. Every verification must confirm the objective is met. Show me the evidence (test output, CLI output, etc.). If any verification fails or the objective is not fully achieved, iterate on the implementation before moving to review.
@@ -198,7 +198,7 @@ For each phase, in order:
    - Does this match your expectations?
    - Any edge cases I missed?
    - Any adjustments needed before Phase N+1?
-6. **Git Checkpoint** 🔴 (MANDATORY — this is your rollback safety net):
+6. **Git Checkpoint** 🔴 (MANDATORY - this is your rollback safety net):
    - After I confirm the pair review, invoke the **git-ci** prompt template to:
      1. Stage all changes (`git add`)
      2. Generate a commit message and branch name (e.g., `feat/<scope>/<what>`, `fix/<scope>/<what>`)
@@ -215,7 +215,7 @@ For each phase, in order:
 
 For phases that are inherently risky (touching auth, payments, data migrations, concurrency, shared infrastructure) or span 5+ files with non-trivial logic, you MUST suggest an independent review after step 5 (Pair Review) and before step 6 (Git Checkpoint):
 
-> **Remind me**: "Phase N is complex enough to warrant an independent review. I recommend spawning a fresh pi-agent using the `review` prompt template to review the staged changes before we commit. The reviewer agent MUST use a **different model** than the one that wrote the code (e.g., if I used `deepseek-v4-pro` to code, use `mimo-v2.5-pro` or `gpt-5.1` to review). Different models have different blind spots — a second pair of eyes from a different model family catches issues the coding model missed."
+> **Remind me**: "Phase N is complex enough to warrant an independent review. I recommend spawning a fresh pi-agent using the `review` prompt template to review the staged changes before we commit. The reviewer agent MUST use a **different model** than the one that wrote the code (e.g., if I used `deepseek-v4-pro` to code, use `mimo-v2.5-pro` or `gpt-5.1` to review). Different models have different blind spots - a second pair of eyes from a different model family catches issues the coding model missed."
 
 If I decline, proceed with the Git Checkpoint. If I accept, pause until the review agent returns its findings, address any issues, then proceed with the Git Checkpoint.
 

--- a/home-manager/config/pi/skills/bash-scripting/SKILL.md
+++ b/home-manager/config/pi/skills/bash-scripting/SKILL.md
@@ -16,7 +16,7 @@ Shell is the right tool for:
 
 ## Which Shell
 
-Target **bash** (not `sh`, not `zsh`). Bash gives us `[[ ]]`, arrays, `readarray`, `local -n`, and `%(...)T` in `printf`. Scripts run on Debian/Ubuntu (bash at `/bin/bash`) and RHEL/CentOS — always invoke via `env` for portability.
+Target **bash** (not `sh`, not `zsh`). Bash gives us `[[ ]]`, arrays, `readarray`, `local -n`, and `%(...)T` in `printf`. Scripts run on Debian/Ubuntu (bash at `/bin/bash`) and RHEL/CentOS - always invoke via `env` for portability.
 
 ## Script Structure
 
@@ -24,7 +24,7 @@ Every script follows this skeleton:
 
 ```bash
 #!/usr/bin/env bash
-# script_name.sh — One-line description of what this script does.
+# script_name.sh - One-line description of what this script does.
 #
 # Usage:  ./script_name.sh [options]
 #
@@ -59,8 +59,8 @@ Always `#!/usr/bin/env bash`. Hardcoding `/bin/bash` breaks on systems where bas
 set -uo pipefail
 ```
 
-- `-u` — reject undefined variables (catches typos early)
-- `-o pipefail` — a pipeline fails if *any* command in it fails
+- `-u` - reject undefined variables (catches typos early)
+- `-o pipefail` - a pipeline fails if *any* command in it fails
 
 **Do not use `set -e`** (errexit). It has surprising edge cases: it does not trigger inside `(( ))` evaluating to 0, inside `let`, or when a failing command is the condition of `if`/`while`/`||`/`&&`. It also turns off inside subshells. Explicit error checks are predictable; `set -e` is not.
 
@@ -161,14 +161,14 @@ Lowercase with underscores: `backup_database.sh`, `rotate_logs.sh`. No hyphens.
 process_file "${input_file}"
 cp "${src}" "${dst}"
 
-# Wrong — word splitting, globbing
+# Wrong - word splitting, globbing
 process_file ${input_file}
 ```
 
 Array expansions always use the quoted form:
 
 ```bash
-"${array[@]}"    # each element as a separate word — this is 99% of cases
+"${array[@]}"    # each element as a separate word - this is 99% of cases
 "${array[*]}"    # all elements as a single string (rarely what you want)
 ```
 
@@ -182,7 +182,7 @@ Array expansions always use the quoted form:
 However, the right-hand side of `==` / `!=` in `[[ ]]` **is** a pattern when unquoted:
 
 ```bash
-[[ ${filename} == *.log ]]  # pattern match — "ends with .log"
+[[ ${filename} == *.log ]]  # pattern match - "ends with .log"
 [[ ${filename} == "*.log" ]] # literal string "*.log"
 ```
 
@@ -224,27 +224,27 @@ fi
 ### Equality: `==` Over `=`
 
 ```bash
-[[ "${name}" == "admin" ]]   # preferred — clearly a comparison, not an assignment
+[[ "${name}" == "admin" ]]   # preferred - clearly a comparison, not an assignment
 [[ "${name}" = "admin" ]]    # works but avoid
 ```
 
 ### Empty / Non-Empty Tests
 
-Be explicit — use `-z` (zero-length) and `-n` (non-zero-length):
+Be explicit - use `-z` (zero-length) and `-n` (non-zero-length):
 
 ```bash
-# Preferred — intent is obvious
+# Preferred - intent is obvious
 if [[ -z "${value}" ]]; then … fi
 if [[ -n "${value}" ]]; then … fi
 
-# Avoid — implicit, easy to misread
+# Avoid - implicit, easy to misread
 if [[ "${value}" ]]; then … fi
 if [[ ! "${value}" ]]; then … fi
 ```
 
 ### Numeric Comparisons
 
-**Never** use `<` `>` inside `[[ ]]` — they perform **lexicographic** comparison (so `"22" < "3"` is true!).
+**Never** use `<` `>` inside `[[ ]]` - they perform **lexicographic** comparison (so `"22" < "3"` is true!).
 
 Use `(( ))` for arithmetic tests, or `-lt` `-gt` `-le` `-ge` `-eq` `-ne` inside `[[ ]]`:
 
@@ -253,7 +253,7 @@ Use `(( ))` for arithmetic tests, or `-lt` `-gt` `-le` `-ge` `-eq` `-ne` inside 
 if (( count > 3 )); then … fi
 if [[ "${count}" -gt 3 ]]; then … fi
 
-# Wrong — lexicographic, not numeric
+# Wrong - lexicographic, not numeric
 if [[ "${count}" > 3 ]]; then … fi
 ```
 
@@ -298,14 +298,14 @@ Every variable inside a function **must** be declared `local`. This prevents pol
 **Critical rule**: separate `local` declaration from `$(…)` assignment. `local` swallows the command's exit code:
 
 ```bash
-# Correct — exit code of my_func is preserved
+# Correct - exit code of my_func is preserved
 my_function() {
   local result
   result="$(my_func)" || return
   …
 }
 
-# Wrong — $? is always 0 (the exit code of `local`, not `my_func`)
+# Wrong - $? is always 0 (the exit code of `local`, not `my_func`)
 my_function() {
   local result="$(my_func)"
   (( $? == 0 )) || return   # this check is useless!
@@ -345,12 +345,12 @@ cd "${work_dir}" || die "Cannot enter: ${work_dir}"
 ### Checking Command Exit Status
 
 ```bash
-# Preferred — check directly in if/||
+# Preferred - check directly in if/||
 if ! mv "${files[@]}" "${dest}/"; then
   die "Cannot move files to ${dest}"
 fi
 
-# Also acceptable — explicit $? check
+# Also acceptable - explicit $? check
 mv "${files[@]}" "${dest}/"
 if (( $? != 0 )); then
   die "Cannot move files to ${dest}"
@@ -377,7 +377,7 @@ fi
 With `set -o pipefail`, a pipeline fails if any component fails:
 
 ```bash
-# If grep fails, the pipeline fails — good
+# If grep fails, the pipeline fails - good
 grep "ERROR" /var/log/app.log | wc -l
 ```
 
@@ -390,16 +390,16 @@ Use `(( … ))` for arithmetic evaluation and `$(( … ))` for expansion:
 (( i += 3 ))
 if (( a < b )); then … fi
 
-# Expansion (with $) — inside strings or assignments
+# Expansion (with $) - inside strings or assignments
 echo "$(( 2 + 2 )) is 4"
 total="$(( price * quantity ))"
 ```
 
 ### Never Use
 
-- `let` — subject to word splitting, non-obvious
-- `$[ … ]` — deprecated, non-portable
-- `expr` — external process, slow, quoting headaches
+- `let` - subject to word splitting, non-obvious
+- `$[ … ]` - deprecated, non-portable
+- `expr` - external process, slow, quoting headaches
 
 ```bash
 # Wrong
@@ -417,13 +417,13 @@ With `set -e` enabled (which we avoid), `(( 0 ))` evaluates to 1 and **causes th
 Use arrays for lists of arguments, file paths, or any collection of strings. Never concatenate arguments into a single string:
 
 ```bash
-# Correct — array
+# Correct - array
 declare -a rsync_flags
 rsync_flags=(--archive --compress --delete)
 rsync_flags+=(--exclude='*.tmp')
 rsync "${rsync_flags[@]}" "${src}/" "${dst}/"
 
-# Wrong — string masquerading as list
+# Wrong - string masquerading as list
 rsync_flags="--archive --compress --delete"
 rsync_flags+=" --exclude='*.tmp'"   # quoting nightmare
 rsync ${rsync_flags} "${src}/" "${dst}/"  # word splitting, globbing bugs
@@ -440,7 +440,7 @@ ${#arr[@]}    # array length
 ### Command Substitution Does Not Return Arrays
 
 ```bash
-# Wrong — word splitting, globbing on output
+# Wrong - word splitting, globbing on output
 declare -a files=($(ls /tmp))
 
 # Correct
@@ -454,7 +454,7 @@ readarray -t files < <(find /tmp -type f)
 Pipes create subshells. Variables modified inside a pipe are **lost** when the pipe ends:
 
 ```bash
-# Wrong — last_line is always 'NULL'
+# Wrong - last_line is always 'NULL'
 last_line='NULL'
 your_command | while read -r line; do
   last_line="${line}"
@@ -464,7 +464,7 @@ echo "${last_line}"   # prints 'NULL'
 
 ### Solutions
 
-**Process substitution** — redirect into `while` without piping:
+**Process substitution** - redirect into `while` without piping:
 
 ```bash
 last_line='NULL'
@@ -474,7 +474,7 @@ done < <(your_command)
 echo "${last_line}"   # correct
 ```
 
-**readarray** — read entire output into an array, then iterate:
+**readarray** - read entire output into an array, then iterate:
 
 ```bash
 readarray -t lines < <(your_command)
@@ -486,7 +486,7 @@ done
 ### `for var in $(cmd)` Splits on Whitespace
 
 ```bash
-# Wrong — splits on any whitespace, globs filenames
+# Wrong - splits on any whitespace, globs filenames
 for file in $(find . -name '*.txt'); do … done
 
 # Correct
@@ -497,7 +497,7 @@ done < <(find . -name '*.txt')
 
 ## Command Substitution
 
-Use `$(…)` — never backticks. Backticks don't nest cleanly and are hard to read:
+Use `$(…)` - never backticks. Backticks don't nest cleanly and are hard to read:
 
 ```bash
 # Correct
@@ -518,16 +518,16 @@ output="$(risky_command)" || die "risky_command failed"
 ### Don't Capture Stderr Into Substitution
 
 ```bash
-# stderr goes to caller's stderr, stdout captured — good
+# stderr goes to caller's stderr, stdout captured - good
 result="$(cmd)"
 
-# stderr mixed into result — usually wrong
+# stderr mixed into result - usually wrong
 result="$(cmd 2>&1)"
 ```
 
 ## Builtins Over External Commands
 
-Prefer bash builtins — they are faster and avoid spawning processes:
+Prefer bash builtins - they are faster and avoid spawning processes:
 
 | Instead of                          | Use bash builtin                    |
 |-------------------------------------|-------------------------------------|
@@ -540,13 +540,13 @@ Prefer bash builtins — they are faster and avoid spawning processes:
 | `$(date +%s)`                       | `printf '%(%s)T' -1`               |
 
 ```bash
-# Correct — all builtin, zero subshells
+# Correct - all builtin, zero subshells
 path="/var/log/app.log"
 name="${path##*/}"                    # "app.log"
 dir="${path%/*}"                      # "/var/log"
 timestamp="$(printf '%(%Y%m%d-%H%M%S)T' -1)"
 
-# Wrong — 3 extra processes
+# Wrong - 3 extra processes
 name=$(basename "${path}")
 dir=$(dirname "${path}")
 timestamp=$(date +%Y%m%d-%H%M%S)
@@ -571,12 +571,12 @@ _die() {
 
 Key points:
 - `_log` writes to stdout; `_die` writes to stderr with `>&2`
-- Use `printf`, not `echo` — `echo` varies across shells with `-n`, `-e`, backslashes
-- `%()T` with `-1` is bash builtin `printf` time formatting — avoids a `date` subshell
+- Use `printf`, not `echo` - `echo` varies across shells with `-n`, `-e`, backslashes
+- `%()T` with `-1` is bash builtin `printf` time formatting - avoids a `date` subshell
 
 ### stdout vs stderr
 
-- **stdout** (fd 1): data output — what your script produces
+- **stdout** (fd 1): data output - what your script produces
 - **stderr** (fd 2): diagnostics, errors, progress messages
 
 Keep stdout clean for piping and command substitution:
@@ -598,10 +598,10 @@ generate_report 2> errors.log  # diagnostics go to error log
 Filenames can start with `-`, which commands interpret as flags:
 
 ```bash
-# Dangerous — if any file starts with '-', it becomes an rm flag
+# Dangerous - if any file starts with '-', it becomes an rm flag
 rm -v *
 
-# Safe — './-f' is a filename, not a flag
+# Safe - './-f' is a filename, not a flag
 rm -v ./*
 ```
 
@@ -633,7 +633,7 @@ done
 
 ### Forwarding Arguments
 
-Always quote `"$@"` — each argument stays intact:
+Always quote `"$@"` - each argument stays intact:
 
 ```bash
 wrapper() {
@@ -667,7 +667,7 @@ Every script starts with a header block:
 
 ```bash
 #!/usr/bin/env bash
-# script_name.sh — One-line description.
+# script_name.sh - One-line description.
 #
 # Usage:  ./script_name.sh <arg1> [arg2]
 #
@@ -677,7 +677,7 @@ Every script starts with a header block:
 
 ### Function or Implementation Comments
 
-**Never** use comments inside or above functions, methods, or any line of code. Code must be self-documenting — clear function names, well-scoped locals, and single-responsibility functions remove the need for explanatory comments. No block comments above `main()`, helper functions, or any function definition. No inline comments explaining what a line does.
+**Never** use comments inside or above functions, methods, or any line of code. Code must be self-documenting - clear function names, well-scoped locals, and single-responsibility functions remove the need for explanatory comments. No block comments above `main()`, helper functions, or any function definition. No inline comments explaining what a line does.
 
 ### TODO Comments
 

--- a/home-manager/config/pi/skills/laravel-best-practices/SKILL.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/SKILL.md
@@ -12,9 +12,9 @@ Best practices for Laravel, prioritized by impact. Each rule teaches what to do 
 
 ## Consistency First
 
-Before applying any rule, check what the application already does. Laravel offers multiple valid approaches — the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
+Before applying any rule, check what the application already does. Laravel offers multiple valid approaches - the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
 
-Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it — don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
+Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it - don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
 
 ## Quick Reference
 
@@ -43,7 +43,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 3. Security → `rules/security.md`
 
 - Define `$fillable` or `$guarded` on every model, authorize every action via policies or gates
-- No raw SQL with user input — use Eloquent or query builder
+- No raw SQL with user input - use Eloquent or query builder
 - `{{ }}` for output escaping, `@csrf` on all POST/PUT/DELETE forms, `throttle` on auth and API routes
 - Validate MIME type, extension, and size for file uploads
 - Never commit `.env`, use `config()` for secrets, `encrypted` cast for sensitive DB fields
@@ -63,17 +63,17 @@ Check sibling files, related controllers, models, or tests for established patte
 
 - Correct relationship types with return type hints
 - Local scopes for reusable query constraints
-- Global scopes sparingly — document their existence
+- Global scopes sparingly - document their existence
 - Attribute casts in the `casts()` method
 - Cast date columns, use Carbon instances in templates
 - `whereBelongsTo($model)` for cleaner queries
-- Never hardcode table names — use `(new Model)->getTable()` or Eloquent queries
+- Never hardcode table names - use `(new Model)->getTable()` or Eloquent queries
 
 ### 6. Validation & Forms → `rules/validation.md`
 
 - Form Request classes, not inline validation
 - Array notation `['required', 'email']` for new code; follow existing convention
-- `$request->validated()` only — never `$request->all()`
+- `$request->validated()` only - never `$request->all()`
 - `Rule::when()` for conditional validation
 - `after()` instead of `withValidator()`
 
@@ -88,7 +88,7 @@ Check sibling files, related controllers, models, or tests for established patte
 - `LazilyRefreshDatabase` over `RefreshDatabase` for speed
 - `assertModelExists()` over raw `assertDatabaseHas()`
 - Factory states and sequences over manual overrides
-- Use fakes (`Event::fake()`, `Exceptions::fake()`, etc.) — but always after factory setup, not before
+- Use fakes (`Event::fake()`, `Exceptions::fake()`, etc.) - but always after factory setup, not before
 - `recycle()` to share relationship instances across factories
 
 ### 9. Queue & Job Patterns → `rules/queue-jobs.md`
@@ -104,7 +104,7 @@ Check sibling files, related controllers, models, or tests for established patte
 - Implicit route model binding
 - Scoped bindings for nested resources
 - `Route::resource()` or `apiResource()`
-- Methods under 10 lines — extract to actions/services
+- Methods under 10 lines - extract to actions/services
 - Type-hint Form Requests for auto-validation
 
 ### 11. HTTP Client → `rules/http-client.md`
@@ -127,7 +127,7 @@ Check sibling files, related controllers, models, or tests for established patte
 
 ### 13. Error Handling → `rules/error-handling.md`
 
-- `report()`/`render()` on exception classes or in `bootstrap/app.php` — follow existing pattern
+- `report()`/`render()` on exception classes or in `bootstrap/app.php` - follow existing pattern
 - `ShouldntReport` for exceptions that should never log
 - Throttle high-volume exceptions to protect log sinks
 - `dontReportDuplicates()` for multi-catch scenarios
@@ -158,12 +158,12 @@ Check sibling files, related controllers, models, or tests for established patte
 - Add indexes in the migration, not as an afterthought
 - Mirror column defaults in model `$attributes`
 - Reversible `down()` by default; forward-fix migrations for intentionally irreversible changes
-- One concern per migration — never mix DDL and DML
+- One concern per migration - never mix DDL and DML
 
 ### 17. Collections → `rules/collections.md`
 
 - Higher-order messages for simple collection operations
-- `cursor()` vs. `lazy()` — choose based on relationship needs
+- `cursor()` vs. `lazy()` - choose based on relationship needs
 - `lazyById()` when updating records while iterating
 - `toQuery()` for bulk operations on collections
 
@@ -186,5 +186,5 @@ Check sibling files, related controllers, models, or tests for established patte
 Always use a sub-agent to read rule files and explore this skill's content.
 
 1. Identify the file type and select relevant sections (e.g., migration → §16, controller → §1, §3, §5, §6, §10)
-2. Check sibling files for existing patterns — follow those first per Consistency First
+2. Check sibling files for existing patterns - follow those first per Consistency First
 3. Verify API syntax with `search-docs` for the installed Laravel version

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/advanced-queries.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/advanced-queries.md
@@ -2,7 +2,7 @@
 
 ## Use `addSelect()` Subqueries for Single Values from Has-Many
 
-Instead of eager-loading an entire has-many relationship for a single value (like the latest timestamp), use a correlated subquery via `addSelect()`. This pulls the value directly in the main SQL query — zero extra queries.
+Instead of eager-loading an entire has-many relationship for a single value (like the latest timestamp), use a correlated subquery via `addSelect()`. This pulls the value directly in the main SQL query - zero extra queries.
 
 ```php
 public function scopeWithLastLoginAt($query): void
@@ -80,13 +80,13 @@ Running a small, targeted secondary query and passing its results via `whereIn` 
 
 ## Use Compound Indexes Matching `orderBy` Column Order
 
-When ordering by multiple columns, create a single compound index in the same column order as the `ORDER BY` clause. Individual single-column indexes cannot combine for multi-column sorts — the database will filesort without a compound index.
+When ordering by multiple columns, create a single compound index in the same column order as the `ORDER BY` clause. Individual single-column indexes cannot combine for multi-column sorts - the database will filesort without a compound index.
 
 ```php
 // Migration
 $table->index(['last_name', 'first_name']);
 
-// Query — column order must match the index
+// Query - column order must match the index
 User::query()->orderBy('last_name')->orderBy('first_name')->paginate();
 ```
 

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/architecture.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/architecture.md
@@ -114,7 +114,7 @@ When no Laravel helper exists, prefer `mb_strlen`, `mb_strtolower`, etc. for UTF
 Incorrect:
 ```php
 strlen('José');          // 5 (bytes, not characters)
-strtolower('MÜNCHEN');  // 'mÜnchen' — fails on multibyte
+strtolower('MÜNCHEN');  // 'mÜnchen' - fails on multibyte
 ```
 
 Correct:
@@ -129,7 +129,7 @@ Str::lower('MÜNCHEN');        // 'münchen'
 
 ## Use `defer()` for Post-Response Work
 
-For lightweight tasks that don't need to survive a crash (logging, analytics, cleanup), use `defer()` instead of dispatching a job. The callback runs after the HTTP response is sent — no queue overhead.
+For lightweight tasks that don't need to survive a crash (logging, analytics, cleanup), use `defer()` instead of dispatching a job. The callback runs after the HTTP response is sent - no queue overhead.
 
 Incorrect (job overhead for trivial work):
 ```php
@@ -145,13 +145,13 @@ Use jobs when the work must survive process crashes or needs retry logic. Use `d
 
 ## Use `Context` for Request-Scoped Data
 
-The `Context` facade passes data through the entire request lifecycle — middleware, controllers, jobs, logs — without passing arguments manually.
+The `Context` facade passes data through the entire request lifecycle - middleware, controllers, jobs, logs - without passing arguments manually.
 
 ```php
 // In middleware
 Context::add('tenant_id', $request->header('X-Tenant-ID'));
 
-// Anywhere later — controllers, jobs, log context
+// Anywhere later - controllers, jobs, log context
 $tenantId = Context::get('tenant_id');
 ```
 
@@ -159,7 +159,7 @@ Context data automatically propagates to queued jobs and is included in log entr
 
 ## Use `Concurrency::run()` for Parallel Execution
 
-Run independent operations in parallel using child processes — no async libraries needed.
+Run independent operations in parallel using child processes - no async libraries needed.
 
 ```php
 use Illuminate\Support\Facades\Concurrency;

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/caching.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/caching.md
@@ -24,17 +24,17 @@ On high-traffic keys, one user always gets a slow response when the cache expire
 
 Incorrect: `Cache::remember('users', 300, fn () => User::all());`
 
-Correct: `Cache::flexible('users', [300, 600], fn () => User::all());` — fresh for 5 min, stale-but-served up to 10 min, refreshes via deferred function.
+Correct: `Cache::flexible('users', [300, 600], fn () => User::all());` - fresh for 5 min, stale-but-served up to 10 min, refreshes via deferred function.
 
 ## Use `Cache::memo()` to Avoid Redundant Hits Within a Request
 
 If the same cache key is read multiple times per request (e.g., a service called from multiple places), `memo()` stores the resolved value in memory.
 
-`Cache::memo()->get('settings');` — 5 calls = 1 Redis round-trip instead of 5.
+`Cache::memo()->get('settings');` - 5 calls = 1 Redis round-trip instead of 5.
 
 ## Use Cache Tags to Invalidate Related Groups
 
-Without tags, invalidating a group of entries requires tracking every key. Tags let you flush atomically. Only works with `redis`, `memcached`, `dynamodb` — not `file` or `database`.
+Without tags, invalidating a group of entries requires tracking every key. Tags let you flush atomically. Only works with `redis`, `memcached`, `dynamodb` - not `file` or `database`.
 
 ```php
 Cache::tags(['user-1'])->flush();
@@ -42,7 +42,7 @@ Cache::tags(['user-1'])->flush();
 
 ## Use `Cache::add()` for Atomic Conditional Writes
 
-`add()` only writes if the key does not exist — atomic, no race condition between checking and writing.
+`add()` only writes if the key does not exist - atomic, no race condition between checking and writing.
 
 Incorrect: `if (! Cache::has('lock')) { Cache::put('lock', true, 10); }`
 
@@ -50,7 +50,7 @@ Correct: `Cache::add('lock', true, 10);`
 
 ## Use `once()` for Per-Request Memoization
 
-`once()` memoizes a function's return value for the lifetime of the object (or request for closures). Unlike `Cache::memo()`, it doesn't hit the cache store at all — pure in-memory.
+`once()` memoizes a function's return value for the lifetime of the object (or request for closures). Unlike `Cache::memo()`, it doesn't hit the cache store at all - pure in-memory.
 
 ```php
 public function roles(): Collection

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/collections.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/collections.md
@@ -15,16 +15,16 @@ Works with `each`, `map`, `sum`, `filter`, `reject`, `contains`, etc.
 
 ## Choose `cursor()` vs. `lazy()` Correctly
 
-- `cursor()` — one model in memory, but cannot eager-load relationships (N+1 risk).
-- `lazy()` — chunked pagination returning a flat LazyCollection, supports eager loading.
+- `cursor()` - one model in memory, but cannot eager-load relationships (N+1 risk).
+- `lazy()` - chunked pagination returning a flat LazyCollection, supports eager loading.
 
-Incorrect: `User::with('roles')->cursor()` — eager loading silently ignored.
+Incorrect: `User::with('roles')->cursor()` - eager loading silently ignored.
 
 Correct: `User::with('roles')->lazy()` for relationship access; `User::cursor()` for attribute-only work.
 
 ## Use `lazyById()` When Updating Records While Iterating
 
-`lazy()` uses offset pagination — updating records during iteration can skip or double-process. `lazyById()` uses `id > last_id`, safe against mutation.
+`lazy()` uses offset pagination - updating records during iteration can skip or double-process. `lazyById()` uses `id > last_id`, safe against mutation.
 
 ## Use `toQuery()` for Bulk Operations on Collections
 

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/config.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/config.md
@@ -63,7 +63,7 @@ return $this->type === 'normal';
 return $this->type === self::TYPE_NORMAL;
 ```
 
-If the application already uses language files for localization, use `__()` for user-facing strings too. Do not introduce language files purely for English-only apps — simple string literals are fine there.
+If the application already uses language files for localization, use `__()` for user-facing strings too. Do not introduce language files purely for English-only apps - simple string literals are fine there.
 
 ```php
 // Only when lang files already exist in the project

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/db-performance.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/db-performance.md
@@ -2,9 +2,9 @@
 
 ## Always Eager Load Relationships
 
-Lazy loading causes N+1 query problems — one query per loop iteration. Always use `with()` to load relationships upfront.
+Lazy loading causes N+1 query problems - one query per loop iteration. Always use `with()` to load relationships upfront.
 
-Incorrect (N+1 — executes 1 + N queries):
+Incorrect (N+1 - executes 1 + N queries):
 ```php
 $posts = Post::all();
 foreach ($posts as $post) {
@@ -46,7 +46,7 @@ Throws `LazyLoadingViolationException` when a relationship is accessed without b
 
 ## Select Only Needed Columns
 
-Avoid `SELECT *` — especially when tables have large text or JSON columns.
+Avoid `SELECT *` - especially when tables have large text or JSON columns.
 
 Incorrect:
 ```php
@@ -83,7 +83,7 @@ User::where('subscribed', true)->chunk(200, function ($users) {
 });
 ```
 
-Use `chunkById()` when modifying records during iteration — standard `chunk()` uses OFFSET which shifts when rows change:
+Use `chunkById()` when modifying records during iteration - standard `chunk()` uses OFFSET which shifts when rows change:
 
 ```php
 User::where('active', false)->chunkById(200, function ($users) {

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/eloquent.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/eloquent.md
@@ -134,15 +134,15 @@ $query->join('companies', 'companies.id', '=', 'users.company_id');
 DB::select('SELECT * FROM orders WHERE status = ?', ['pending']);
 ```
 
-Correct — reference the model's table:
+Correct - reference the model's table:
 ```php
 DB::table((new User)->getTable())->where('active', true)->get();
 
-// Even better — use Eloquent or the query builder instead of raw SQL
+// Even better - use Eloquent or the query builder instead of raw SQL
 User::where('active', true)->get();
 Order::where('status', 'pending')->get();
 ```
 
-Prefer Eloquent queries and relationships over `DB::table()` whenever possible — they already reference the model's table. When `DB::table()` or raw joins are unavoidable, always use `(new Model)->getTable()` to keep the reference traceable.
+Prefer Eloquent queries and relationships over `DB::table()` whenever possible - they already reference the model's table. When `DB::table()` or raw joins are unavoidable, always use `(new Model)->getTable()` to keep the reference traceable.
 
-**Exception — migrations:** In migrations, hardcoded table names via `DB::table('settings')` are acceptable and preferred. Models change over time but migrations are frozen snapshots — referencing a model that is later renamed or deleted would break the migration.
+**Exception - migrations:** In migrations, hardcoded table names via `DB::table('settings')` are acceptable and preferred. Models change over time but migrations are frozen snapshots - referencing a model that is later renamed or deleted would break the migration.

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/error-handling.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/error-handling.md
@@ -2,9 +2,9 @@
 
 ## Exception Reporting and Rendering
 
-There are two valid approaches — choose one and apply it consistently across the project.
+There are two valid approaches - choose one and apply it consistently across the project.
 
-**Co-location on the exception class** — keeps behavior alongside the exception definition, easier to find:
+**Co-location on the exception class** - keeps behavior alongside the exception definition, easier to find:
 
 ```php
 class InvalidOrderException extends Exception
@@ -18,7 +18,7 @@ class InvalidOrderException extends Exception
 }
 ```
 
-**Centralized in `bootstrap/app.php`** — all exception handling in one place, easier to see the full picture:
+**Centralized in `bootstrap/app.php`** - all exception handling in one place, easier to see the full picture:
 
 ```php
 ->withExceptions(function (Exceptions $exceptions) {
@@ -59,7 +59,7 @@ $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
 
 ## Add Context to Exception Classes
 
-Attach structured data to exceptions at the source via a `context()` method — Laravel includes it automatically in the log entry.
+Attach structured data to exceptions at the source via a `context()` method - Laravel includes it automatically in the log entry.
 
 ```php
 class InvalidOrderException extends Exception

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/events-notifications.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/events-notifications.md
@@ -29,7 +29,7 @@ class InvoicePaid extends Notification implements ShouldQueue
 
 ## Use `afterCommit()` on Notifications in Transactions
 
-Same race condition as events — call `afterCommit()` to delay dispatch until the transaction commits.
+Same race condition as events - call `afterCommit()` to delay dispatch until the transaction commits.
 
 ```php
 $user->notify((new InvoicePaid($invoice))->afterCommit());
@@ -49,4 +49,4 @@ Notification::route('mail', 'admin@example.com')->notify(new SystemAlert());
 
 ## Implement `HasLocalePreference` on Notifiable Models
 
-Laravel automatically uses the user's preferred locale for all notifications and mailables — no per-call `locale()` needed.
+Laravel automatically uses the user's preferred locale for all notifications and mailables - no per-call `locale()` needed.

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/http-client.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/http-client.md
@@ -2,7 +2,7 @@
 
 ## Always Set Explicit Timeouts
 
-The default timeout is 30 seconds — too long for most API calls. Always set explicit `timeout` and `connectTimeout` to fail fast.
+The default timeout is 30 seconds - too long for most API calls. Always set explicit `timeout` and `connectTimeout` to fail fast.
 
 Incorrect:
 ```php

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/mail.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/mail.md
@@ -2,7 +2,7 @@
 
 ## Implement `ShouldQueue` on the Mailable Class
 
-Makes queueing the default regardless of how the mailable is dispatched. No need to remember `Mail::queue()` at every call site — `Mail::send()` also queues it.
+Makes queueing the default regardless of how the mailable is dispatched. No need to remember `Mail::queue()` at every call site - `Mail::send()` also queues it.
 
 ## Use `afterCommit()` on Mailables Inside Transactions
 
@@ -24,4 +24,4 @@ Markdown mailables auto-generate both HTML and plain-text versions, use responsi
 
 Content tests: instantiate the mailable directly, call `assertSeeInHtml()`.
 Sending tests: use `Mail::fake()` and `assertSent()`/`assertQueued()`.
-Don't mix them — it conflates concerns and makes tests brittle.
+Don't mix them - it conflates concerns and makes tests brittle.

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/migrations.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/migrations.md
@@ -32,7 +32,7 @@ Once a migration has run in production, treat it as immutable. Create a new migr
 
 Incorrect (editing a deployed migration):
 ```php
-// 2024_01_01_create_posts_table.php — already in production
+// 2024_01_01_create_posts_table.php - already in production
 $table->string('slug')->unique(); // ← added after deployment
 ```
 

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/queue-jobs.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/queue-jobs.md
@@ -11,7 +11,7 @@ class ProcessReport implements ShouldQueue
     public $timeout = 120;
 }
 
-// config/queue.php — retry_after: 90 ← job retried while still running!
+// config/queue.php - retry_after: 90 ← job retried while still running!
 ```
 
 Correct (`retry_after` > `timeout`):
@@ -21,7 +21,7 @@ class ProcessReport implements ShouldQueue
     public $timeout = 120;
 }
 
-// config/queue.php — retry_after: 180 ← safely longer than any job timeout
+// config/queue.php - retry_after: 180 ← safely longer than any job timeout
 ```
 
 ## Use Exponential Backoff
@@ -64,7 +64,7 @@ class GenerateInvoice implements ShouldQueue, ShouldBeUnique
 
 ## Always Implement `failed()`
 
-Handle errors explicitly — don't rely on silent failure.
+Handle errors explicitly - don't rely on silent failure.
 
 ```php
 public function failed(?Throwable $exception): void

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/routing.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/routing.md
@@ -36,7 +36,7 @@ Use `Route::resource()` or `apiResource()` for RESTful endpoints.
 
 ```php
 Route::resource('posts', PostController::class);
-// In routes/api.php — the /api prefix is applied automatically
+// In routes/api.php - the /api prefix is applied automatically
 Route::apiResource('posts', Api\PostController::class);
 ```
 

--- a/home-manager/config/pi/skills/laravel-best-practices/rules/style.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/rules/style.md
@@ -39,7 +39,7 @@
 
 Laravel provides `Str`, `Arr`, `Number`, and `Uri` helper classes that are more readable, chainable, and UTF-8 safe than raw PHP functions. Always prefer them.
 
-Strings — use `Str` and fluent `Str::of()` over raw PHP:
+Strings - use `Str` and fluent `Str::of()` over raw PHP:
 ```php
 // Incorrect
 $slug = strtolower(str_replace(' ', '-', $title));
@@ -52,7 +52,7 @@ $short = Str::limit($text, 100);
 $class = class_basename('App\Models\User');
 ```
 
-Fluent strings — chain operations for complex transformations:
+Fluent strings - chain operations for complex transformations:
 ```php
 // Incorrect
 $result = strtolower(trim(str_replace('_', '-', $input)));
@@ -63,7 +63,7 @@ $result = Str::of($input)->trim()->replace('_', '-')->lower();
 
 Key `Str` methods to prefer: `Str::slug()`, `Str::limit()`, `Str::contains()`, `Str::before()`, `Str::after()`, `Str::between()`, `Str::camel()`, `Str::snake()`, `Str::kebab()`, `Str::headline()`, `Str::squish()`, `Str::mask()`, `Str::uuid()`, `Str::ulid()`, `Str::random()`, `Str::is()`.
 
-Arrays — use `Arr` over raw PHP:
+Arrays - use `Arr` over raw PHP:
 ```php
 // Incorrect
 $name = isset($array['user']['name']) ? $array['user']['name'] : 'default';
@@ -74,7 +74,7 @@ $name = Arr::get($array, 'user.name', 'default');
 
 Key `Arr` methods: `Arr::get()`, `Arr::has()`, `Arr::only()`, `Arr::except()`, `Arr::first()`, `Arr::flatten()`, `Arr::pluck()`, `Arr::where()`, `Arr::wrap()`.
 
-Numbers — use `Number` for display formatting:
+Numbers - use `Number` for display formatting:
 ```php
 Number::format(1000000);          // "1,000,000"
 Number::currency(1500, 'USD');    // "$1,500.00"
@@ -83,7 +83,7 @@ Number::fileSize(1024 * 1024);    // "1 MB"
 Number::percentage(75.5);         // "75.5%"
 ```
 
-URIs — use `Uri` for URL manipulation:
+URIs - use `Uri` for URL manipulation:
 ```php
 $uri = Uri::of('https://example.com/search')
     ->withQuery(['q' => 'laravel', 'page' => 1]);
@@ -91,7 +91,7 @@ $uri = Uri::of('https://example.com/search')
 
 Use `$request->string('name')` to get a fluent `Stringable` directly from request input for immediate chaining.
 
-Use `search-docs` for the full list of available methods — these helpers are extensive.
+Use `search-docs` for the full list of available methods - these helpers are extensive.
 
 ## No Inline JS/CSS in Blade
 

--- a/home-manager/config/pi/skills/laravel-helper/SKILL.md
+++ b/home-manager/config/pi/skills/laravel-helper/SKILL.md
@@ -6,13 +6,13 @@ description: Assist with Laravel >=10.x development targeting PHP >=8.1. Covers 
 # Laravel Helper Skill
 
 This skill provides guidance for developing Laravel 10.x+ applications with PHP 8.1+.
-Follow these conventions for all Laravel code—new features, refactors, reviews, and bug fixes.
+Follow these conventions for all Laravel code-new features, refactors, reviews, and bug fixes.
 
 ## PHP 8.1+ Modern Features
 
 Prefer these language features over older equivalents:
 
-- **Enums** — Never use string constants or database-backed status tables for fixed sets.
+- **Enums** - Never use string constants or database-backed status tables for fixed sets.
   ```php
   enum OrderStatus: string
   {
@@ -30,7 +30,7 @@ Prefer these language features over older equivalents:
       }
   }
   ```
-- **Readonly properties** — For DTOs, value objects, and data classes.
+- **Readonly properties** - For DTOs, value objects, and data classes.
   ```php
   class CreateOrderDTO
   {
@@ -41,11 +41,11 @@ Prefer these language features over older equivalents:
       ) {}
   }
   ```
-- **Match expressions** — Replace long `switch` chains; `match` is exhaustive.
-- **Named arguments** — Use when calling methods with many optional/default params.
-- **First-class callable syntax** — `$this->method(...)` instead of `[$this, 'method']`.
-- **Array unpacking with string keys** — `[...$array1, ...$array2]`.
-- **`str_contains`, `str_starts_with`, `str_ends_with`** — Replace manual `strpos` checks.
+- **Match expressions** - Replace long `switch` chains; `match` is exhaustive.
+- **Named arguments** - Use when calling methods with many optional/default params.
+- **First-class callable syntax** - `$this->method(...)` instead of `[$this, 'method']`.
+- **Array unpacking with string keys** - `[...$array1, ...$array2]`.
+- **`str_contains`, `str_starts_with`, `str_ends_with`** - Replace manual `strpos` checks.
 
 ## Coding Style & Formatting
 
@@ -99,16 +99,16 @@ app/
 ```
 
 ### Namespacing Rules
-- **Controllers** — Keep thin. Delegate to Actions, Jobs, or Services. Never place business logic here.
-- **Models** — Should contain relationships, accessors/mutators, casts, and scopes only. No HTTP-level logic.
-- **Actions** — One public `execute()` method. Stateless. Named as a verb: `CancelOrder`, `RegisterUser`.
-- **Form Requests** — Always use them for validation. Never validate in controllers.
-- **Services** — Stateful classes coordinating multiple steps (e.g., `CheckoutService`). Prefer Actions for simpler tasks.
+- **Controllers** - Keep thin. Delegate to Actions, Jobs, or Services. Never place business logic here.
+- **Models** - Should contain relationships, accessors/mutators, casts, and scopes only. No HTTP-level logic.
+- **Actions** - One public `execute()` method. Stateless. Named as a verb: `CancelOrder`, `RegisterUser`.
+- **Form Requests** - Always use them for validation. Never validate in controllers.
+- **Services** - Stateful classes coordinating multiple steps (e.g., `CheckoutService`). Prefer Actions for simpler tasks.
 
 ## Eloquent Conventions
 
 - Table names auto-resolve: `User` → `users`, `OrderItem` → `order_items`. Follow this implicitly.
-- Explicitly declare `$fillable` OR `$guarded` — never leave both empty.
+- Explicitly declare `$fillable` OR `$guarded` - never leave both empty.
 - Prefer `$fillable` over `$guarded` for clarity.
 - Cast attributes explicitly in `$casts`:
   ```php

--- a/home-manager/modules/programs/pi.nix
+++ b/home-manager/modules/programs/pi.nix
@@ -15,6 +15,7 @@ _: {
       recursive = true;
     };
     ".pi/agent/extensions/company-provider.ts".source = ../../config/pi/extensions/company-provider.ts;
+    ".pi/agent/APPEND_SYSTEM.md".source = ../../config/pi/APPEND_SYSTEM.md;
     ".pi/agent/README.md".source = ../../config/pi/README.md;
     ".pi/agent/prompts/review.md".source = ../../config/pi/prompts/review.md;
     ".pi/agent/prompts/git-ci.md".source = ../../config/pi/prompts/git-ci.md;


### PR DESCRIPTION
## Summary

- Replace em dashes (—) with hyphens (-) across all prompt and skill markdown files (24 files)
- Add `APPEND_SYSTEM.md` to globally enforce no-em-dash rule for all models
- Wire `APPEND_SYSTEM.md` into `pi.nix` Home Manager configuration

## Details

Pi supports `~/.pi/agent/APPEND_SYSTEM.md` which gets appended to every system prompt for every model. This ensures all future model outputs avoid em dashes, while the 24-file bulk replacement fixes existing instances.