### PR TITLE
feat(claude): manage ~/.claude/ with home-manager

### DIFF
--- a/home-manager/config/claude/settings.json
+++ b/home-manager/config/claude/settings.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "cleanupPeriodDays": 365,
+  "env": {
+    "DISABLE_TELEMETRY": "1",
+    "DISABLE_ERROR_REPORTING": "1",
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enableAllProjectMcpServers": false,
+  "alwaysThinkingEnabled": true,
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(rm -fr *)",
+      "Bash(sudo *)",
+      "Bash(mkfs *)",
+      "Bash(dd *)",
+      "Bash(wget *|bash*)",
+      "Bash(wget *| bash*)",
+      "Bash(git push --force*)",
+      "Bash(git push *--force*)",
+      "Bash(git reset --hard*)",
+
+      "Edit(~/.bashrc)",
+      "Edit(~/.zshrc)",
+      "Edit(~/.ssh/**)",
+
+      "Read(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.azure/**)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.git-credentials)",
+      "Read(~/.docker/config.json)",
+      "Read(~/.kube/**)",
+      "Read(~/.npmrc)",
+      "Read(~/.npm/**)",
+      "Read(~/.pypirc)",
+      "Read(~/.gem/credentials)",
+      "Read(~/Library/Keychains/**)",
+      "Read(~/Library/Application Support/**/metamask*/**)",
+      "Read(~/Library/Application Support/**/electrum*/**)",
+      "Read(~/Library/Application Support/**/exodus*/**)",
+      "Read(~/Library/Application Support/**/phantom*/**)",
+      "Read(~/Library/Application Support/**/solflare*/**)"
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}

--- a/home-manager/config/claude/settings.json
+++ b/home-manager/config/claude/settings.json
@@ -5,10 +5,14 @@
     "DISABLE_TELEMETRY": "1",
     "DISABLE_ERROR_REPORTING": "1",
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-7"
   },
   "enableAllProjectMcpServers": false,
   "alwaysThinkingEnabled": true,
+  "model": "opus[1m]",
+  "theme": "dark-daltonized",
   "permissions": {
     "deny": [
       "Bash(rm -rf *)",
@@ -21,11 +25,9 @@
       "Bash(git push --force*)",
       "Bash(git push *--force*)",
       "Bash(git reset --hard*)",
-
       "Edit(~/.bashrc)",
       "Edit(~/.zshrc)",
       "Edit(~/.ssh/**)",
-
       "Read(~/.ssh/**)",
       "Read(~/.gnupg/**)",
       "Read(~/.aws/**)",

--- a/home-manager/config/claude/statusline.sh
+++ b/home-manager/config/claude/statusline.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+STATUS_JSON="$(cat)"
+readonly STATUS_JSON
+
+parse_json() {
+  jq -r '
+    [
+      (.model.display_name // "Claude"),
+      (.workspace.project_dir // .cwd // ""),
+      (.context_window.used_percentage // "" | tostring),
+      (.context_window.total_input_tokens // 0 | tostring),
+      (.context_window.total_output_tokens // 0 | tostring),
+      (.context_window.current_usage.cache_creation_input_tokens // 0 | tostring),
+      (.context_window.current_usage.cache_read_input_tokens // 0 | tostring),
+      (.transcript_path // ""),
+      (.rate_limits.five_hour.used_percentage // "" | tostring)
+    ] | @tsv
+  ' <<<"${STATUS_JSON}"
+}
+
+build_progress_bar() {
+  local used_pct_str="$1" used_int filled empty
+  [[ -z "${used_pct_str}" ]] && return
+  used_int="$(printf '%.0f' "${used_pct_str}")"
+  filled=$((used_int * 12 / 100))
+  empty=$((12 - filled))
+  printf '%s%s %d%%' \
+    "$(printf '%*s' "${filled}" '' | tr ' ' '█')" \
+    "$(printf '%*s' "${empty}" '' | tr ' ' '░')" \
+    "${used_int}"
+}
+
+calculate_cost() {
+  awk -v ti="$1" -v to="$2" -v cw="$3" -v cr="$4" \
+    'BEGIN { printf "%.2f", (ti*15 + to*75 + cw*18.75 + cr*1.50) / 1000000 }'
+}
+
+parse_iso8601_to_epoch() {
+  local ts="$1" epoch
+  if date --version &>/dev/null 2>&1; then
+    epoch="$(date -d "${ts}" +%s 2>/dev/null)"
+  else
+    epoch="$(date -jf "%Y-%m-%dT%H:%M:%S" "${ts%%.*}" +%s 2>/dev/null)"
+    [[ -z "${epoch}" ]] && epoch="$(date -jf "%Y-%m-%dT%H:%M:%SZ" "${ts}" +%s 2>/dev/null)"
+  fi
+  printf '%s' "${epoch:-0}"
+}
+
+get_elapsed() {
+  local transcript_path="$1" first_ts start_s now_s diff mins secs
+  [[ -z "${transcript_path}" || ! -f "${transcript_path}" ]] && return
+  first_ts="$(head -1 "${transcript_path}" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null)"
+  [[ -z "${first_ts}" ]] && return
+  now_s="$(date +%s)"
+  start_s="$(parse_iso8601_to_epoch "${first_ts}")"
+  [[ "${start_s}" -le 0 ]] && return
+  diff=$((now_s - start_s))
+  mins=$((diff / 60))
+  secs=$((diff % 60))
+  printf '%dm %02ds' "${mins}" "${secs}"
+}
+
+get_branch() {
+  local project_dir="$1" branch
+  [[ -n "${project_dir}" && -d "${project_dir}/.git" ]] || return
+  branch="$(git -C "${project_dir}" --git-dir="${project_dir}/.git" symbolic-ref --short HEAD 2>/dev/null)"
+  [[ -n "${branch}" ]] || branch="$(git -C "${project_dir}" --git-dir="${project_dir}/.git" rev-parse --short HEAD 2>/dev/null)"
+  printf '%s' "${branch}"
+}
+
+join_parts() {
+  local IFS=' │ '
+  printf '%s' "$*"
+}
+
+main() {
+  local model_name project_dir used_pct_str total_input total_output cache_write cache_read transcript_path rate_str
+  IFS=$'\t' read -r model_name project_dir used_pct_str total_input total_output cache_write cache_read transcript_path rate_str <<<"$(parse_json)"
+
+  local model project branch bar cost elapsed rate parts
+  model="[${model_name}]"
+  project="$(basename "${project_dir}")"
+  branch="$(get_branch "${project_dir}")"
+  bar="$(build_progress_bar "${used_pct_str}")"
+  cost="$(calculate_cost "${total_input}" "${total_output}" "${cache_write}" "${cache_read}")"
+  elapsed="$(get_elapsed "${transcript_path}")"
+
+  parts=("${model}")
+
+  [[ -n "${project}" ]] && parts+=("📁 ${project}")
+  [[ -n "${branch}" ]] && parts+=("🌿 ${branch}")
+  [[ -n "${bar}" ]] && parts+=("${bar}")
+  [[ -n "${cost}" && "${cost}" != "0.00" ]] && parts+=("\$${cost}")
+  [[ -n "${elapsed}" ]] && parts+=("⏱ ${elapsed}")
+
+  if [[ -n "${rate_str}" ]]; then
+    rate="$(printf '%.0f' "${rate_str}")"
+    parts+=("↻${rate}%")
+  fi
+
+  join_parts "${parts[@]}"
+}
+
+main

--- a/home-manager/modules/programs/claude.nix
+++ b/home-manager/modules/programs/claude.nix
@@ -1,0 +1,9 @@
+_: {
+  home.file = {
+    ".claude/settings.json".source = ../../config/claude/settings.json;
+    ".claude/statusline.sh" = {
+      source = ../../config/claude/statusline.sh;
+      executable = true;
+    };
+  };
+}

--- a/home-manager/modules/programs/default.nix
+++ b/home-manager/modules/programs/default.nix
@@ -8,5 +8,6 @@
     ./ssh.nix
     ./tmux.nix
     ./pi.nix
+    ./claude.nix
   ];
 }


### PR DESCRIPTION
## Summary

Manage Claude Code configuration (`~/.claude/`) via Home Manager.

## Changes

- **`home-manager/config/claude/settings.json`** — Plaintext settings with permissions, model config, and statusline command reference
- **`home-manager/config/claude/statusline.sh`** — Deep-refactored status line script: single `jq` call, `printf`-based progress bar, zero-comment self-documenting functions
- **`home-manager/modules/programs/claude.nix`** — HM module symlinking settings and statusline into `~/.claude/`
- **`home-manager/modules/programs/default.nix`** — Added `claude.nix` import