### PR TITLE
chore(pi-agent): add grill-me prompt template

### DIFF
--- a/home-manager/config/pi/prompts/grill-me.md
+++ b/home-manager/config/pi/prompts/grill-me.md
@@ -1,0 +1,11 @@
+---
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+adapted-from: https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
+author: Matt Pocock (mattpocock)
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/home-manager/config/pi/prompts/handoff.md
+++ b/home-manager/config/pi/prompts/handoff.md
@@ -1,0 +1,16 @@
+---
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+adapted-from: https://github.com/mattpocock/skills/blob/main/skills/productivity/handoff/SKILL.md
+author: Matt Pocock (mattpocock)
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/home-manager/modules/programs/pi.nix
+++ b/home-manager/modules/programs/pi.nix
@@ -22,5 +22,6 @@ _: {
     ".pi/agent/prompts/spec-workflow.md".source = ../../config/pi/prompts/spec-workflow.md;
     ".pi/agent/prompts/spec-quick.md".source = ../../config/pi/prompts/spec-quick.md;
     ".pi/agent/prompts/grill-me.md".source = ../../config/pi/prompts/grill-me.md;
+    ".pi/agent/prompts/handoff.md".source = ../../config/pi/prompts/handoff.md;
   };
 }

--- a/home-manager/modules/programs/pi.nix
+++ b/home-manager/modules/programs/pi.nix
@@ -21,5 +21,6 @@ _: {
     ".pi/agent/prompts/git-ci.md".source = ../../config/pi/prompts/git-ci.md;
     ".pi/agent/prompts/spec-workflow.md".source = ../../config/pi/prompts/spec-workflow.md;
     ".pi/agent/prompts/spec-quick.md".source = ../../config/pi/prompts/spec-quick.md;
+    ".pi/agent/prompts/grill-me.md".source = ../../config/pi/prompts/grill-me.md;
   };
 }


### PR DESCRIPTION
Add the `grill-me` prompt template to pi-agent, adapted from [Matt Pocock's skills repo](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md).

## Changes
- New prompt template: `home-manager/config/pi/prompts/grill-me.md`
- Wire symlink mapping in `home-manager/modules/programs/pi.nix`

## Usage
After `just switch`, invoke in pi with `/prompt:grill-me` and describe your plan. Pi will interview you one question at a time, walking down each branch of the decision tree.