### PR TITLE
feat: add custom packages infra and kage package

### DIFF
--- a/docs/kage.md
+++ b/docs/kage.md
@@ -1,0 +1,126 @@
+# kage
+
+[kage](https://github.com/tamnd/kage) — shadow any website for offline viewing, with JavaScript stripped out.
+
+## Quick reference
+
+```
+# Build standalone
+nix build .#kage
+
+# Use in home-manager (already wired in cli.nix)
+pkgs.kage
+
+# Run tests
+bats tests/pkgs.bats
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `pkgs/kage.nix` | `buildGoModule` derivation (v0.3.3) |
+| `pkgs/default.nix` | Package registry — maps `kage` to `callPackage ./kage.nix` |
+| `overlays/default.nix` | `additions` / `additionsUnstable` overlays |
+| `tests/pkgs.bats` | Evaluation tests (11 cases) |
+| `flake.nix` | Wires `additionsUnstable` overlay with `pkgsUnstable` |
+
+## How it works
+
+### Go version selection
+
+kage requires `go >= 1.26.4`, but nixpkgs channels top out at 1.26.3 (unstable) and 1.25.5 (stable). The derivation patches `go.mod` down by one patch version and builds with the closest available Go:
+
+```nix
+# pkgs/default.nix
+kage = pkgs.callPackage ./kage.nix {
+  go =
+    if pkgsUnstable ? go_1_26    # 1.26.3 from unstable (preferred)
+    then pkgsUnstable.go_1_26
+    else pkgs.go_1_25;           # 1.25.5 fallback if no unstable
+};
+```
+
+The `pkgsUnstable` parameter flows through the overlay:
+
+```nix
+# flake.nix — in mkHomeConfig
+pkgsUnstable = import nixpkgs-unstable (nixpkgsConfig // { inherit system; });
+pkgs = import nixpkgs (nixpkgsConfig // {
+  inherit system;
+  overlays = [ (overlays.additionsUnstable pkgsUnstable) ];
+});
+```
+
+```nix
+# overlays/default.nix
+additionsUnstable = pkgsUnstable: final: _prev:
+  import ../pkgs { pkgs = final; inherit pkgsUnstable; };
+```
+
+### go.mod patch
+
+The `postPatch` in `pkgs/kage.nix` changes `go 1.26.4` → `go 1.26.3`. This is safe because:
+
+- kage has no 1.26.4-specific language features
+- Go module graph pruning rules are identical within 1.26.x
+- `go mod tidy` is not needed — go.sum format stays the same
+
+## Adding a new custom package
+
+1. Create `pkgs/new-pkg.nix` with your `callPackage`-compatible derivation
+2. Register it in `pkgs/default.nix`:
+   ```nix
+   new-pkg = pkgs.callPackage ./new-pkg.nix { };
+   ```
+3. Add a test in `tests/pkgs.bats`:
+   ```bash
+   @test "packages.new-pkg resolves" {
+     run nix eval --json "path:${FLAKE}#packages.aarch64-darwin.new-pkg.name"
+     [ "$status" -eq 0 ]
+   }
+   ```
+4. Run `just check` to verify evaluation and tests
+
+## When Go 1.26.4 becomes available
+
+Once nixpkgs-unstable ships `go >= 1.26.4`:
+
+**1. Remove the postPatch from `pkgs/kage.nix`:**
+
+```nix
+# Delete this entire block:
+  postPatch = ''
+    substituteInPlace go.mod --replace-fail "go 1.26.4" "go 1.26.3"
+  '';
+```
+
+**2. Simplify the go selection in `pkgs/default.nix`:**
+
+```nix
+kage = pkgs.callPackage ./kage.nix {
+  go = pkgsUnstable.go_1_26;
+};
+```
+
+**3. Recompute `vendorHash`** (likely unchanged, but verify):
+
+```bash
+just switch
+# If hash mismatch, copy the reported hash into pkgs/kage.nix
+```
+
+**4. Un-skip the guard-rail test in `tests/pkgs.bats`:**
+
+```bash
+# Remove the "skip" line from the WORKAROUND test — it will then
+# fail, reminding you to apply the steps above.
+```
+
+## Tests
+
+```bash
+bats tests/pkgs.bats
+```
+
+Covers: package resolution on both systems, Go version selection, overlay wiring, home-manager integration, and meta correctness. The `WORKAROUND` test is skipped by default — un-skip it when Go 1.26.4 lands.

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,16 @@
     agenix,
     ...
   }: let
+    # Shared config for nixpkgs imports
+    nixpkgsConfig = {
+      config.allowUnfree = true;
+      config.permittedInsecurePackages = [
+        "openssl-1.1.1w"
+      ];
+    };
+
+    overlays = import ./overlays;
+
     mkHomeConfig = {
       system,
       username,
@@ -36,20 +46,17 @@
       hasGUI ? true,
       extraModules ? [],
     }: let
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-        config.permittedInsecurePackages = [
-          "openssl-1.1.1w"
-        ];
-      };
-      pkgsUnstable = import nixpkgs-unstable {
-        inherit system;
-        config.allowUnfree = true;
-        config.permittedInsecurePackages = [
-          "openssl-1.1.1w"
-        ];
-      };
+      pkgsUnstable = import nixpkgs-unstable (nixpkgsConfig
+        // {
+          inherit system;
+        });
+      pkgs = import nixpkgs (nixpkgsConfig
+        // {
+          inherit system;
+          overlays = [
+            (overlays.additionsUnstable pkgsUnstable)
+          ];
+        });
       resolvedHomeDir =
         if homeDirectory != null
         then homeDirectory
@@ -82,6 +89,12 @@
           inherit hasGUI;
         };
       };
+
+    # Helper to apply overlays for standalone nixpkgs access
+    forAllSystems = nixpkgs.lib.genAttrs [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
   in {
     homeConfigurations = {
       "quang.van.nguyen@Nguyens-MacBook-Pro.local" = mkHomeConfig {
@@ -116,19 +129,24 @@
       };
     };
 
-    devShells = {
-      aarch64-darwin.default = import ./shell.nix {
-        pkgs = import nixpkgs {
-          system = "aarch64-darwin";
-          config.allowUnfree = true;
-        };
-      };
-      x86_64-linux.default = import ./shell.nix {
-        pkgs = import nixpkgs {
-          system = "x86_64-linux";
-          config.allowUnfree = true;
-        };
-      };
-    };
+    # Custom packages; accessible via 'nix build .#kage', 'nix shell .#kage', etc
+    packages = forAllSystems (
+      system:
+        import ./pkgs {
+          pkgs = import nixpkgs (nixpkgsConfig // {inherit system;});
+          pkgsUnstable = import nixpkgs-unstable (nixpkgsConfig // {inherit system;});
+        }
+    );
+
+    # Custom overlays; consumers can import these
+    inherit overlays;
+
+    devShells = forAllSystems (
+      system: let
+        pkgs = import nixpkgs (nixpkgsConfig // {inherit system;});
+      in {
+        default = import ./shell.nix {inherit pkgs;};
+      }
+    );
   };
 }

--- a/home-manager/modules/core/cli.nix
+++ b/home-manager/modules/core/cli.nix
@@ -27,6 +27,7 @@
       htop
       inetutils
       just
+      kage
       kcat
       libiconv
       mtr

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,15 @@
+# Overlays applied to nixpkgs imports.
+#
+# addions           — makes all packages from ../pkgs available as pkgs.<name>
+#                      using only stable nixpkgs.
+# additionsUnstable — same, but passes pkgs-unstable so packages that need a
+#                      newer Go (e.g. kage) get it without resorting to workarounds.
+{
+  additions = final: _prev: import ../pkgs {pkgs = final;};
+
+  additionsUnstable = pkgsUnstable: final: _prev:
+    import ../pkgs {
+      pkgs = final;
+      inherit pkgsUnstable;
+    };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,0 +1,13 @@
+# Custom packages, built via 'nix build .#kage'
+# Also accessible as pkgs.kage in home-manager via the overlay in ../overlays
+{
+  pkgs,
+  pkgsUnstable ? pkgs,
+}: {
+  # kage needs go >= 1.26.4; unstable has 1.26.3 (closest match).
+  # Falls back to pkgs.go_1_25 when pkgsUnstable is not provided.
+  kage = pkgs.callPackage ./kage.nix {
+    go =
+      pkgsUnstable.go_1_26 or pkgs.go_1_25;
+  };
+}

--- a/pkgs/kage.nix
+++ b/pkgs/kage.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go,
+}:
+(buildGoModule.override {inherit go;})
+rec {
+  pname = "kage";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "tamnd";
+    repo = "kage";
+    rev = "v${version}";
+    hash = "sha256-NZc+/EaVyuJxPzEKi4crwOg55KWMc/Km/QywJ5ywKnc=";
+  };
+
+  vendorHash = "sha256-Jr9rR7qX8KLuzumz4jUfvuUftW+GO1gq/Dj/oT5+Uto=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/tamnd/kage/cli.Version=${version}"
+  ];
+
+  subPackages = ["cmd/kage"];
+
+  env.CGO_ENABLED = "0";
+
+  # kage requires go >= 1.26.4. nixpkgs-unstable has 1.26.3, so we patch down
+  # one patch version. No go mod tidy needed — go.sum format unchanged within 1.26.x.
+  # TODO: remove this postPatch when nixpkgs-unstable ships go >= 1.26.4.
+  postPatch = ''
+    substituteInPlace go.mod --replace-fail "go 1.26.4" "go 1.26.3"
+  '';
+
+  meta = with lib; {
+    description = "Shadow any website for offline viewing, with the JavaScript stripped out";
+    homepage = "https://github.com/tamnd/kage";
+    license = licenses.mit;
+    mainProgram = "kage";
+    platforms = platforms.unix;
+  };
+}

--- a/tests/pkgs.bats
+++ b/tests/pkgs.bats
@@ -1,0 +1,116 @@
+# pkgs.bats — Test suite for custom packages (pkgs/, overlays/)
+#
+# Verifies package resolution, Go version selection, and overlay wiring.
+# These are evaluation-only tests — no builds, no network.
+
+setup() {
+  FLAKE="${BATS_TEST_DIRNAME}/.."
+}
+
+# ---------------------------------------------------------------------------
+# Flake package output
+# ---------------------------------------------------------------------------
+
+@test "packages.kage resolves on aarch64-darwin" {
+  run nix eval --json "path:${FLAKE}#packages.aarch64-darwin.kage.name"
+  [ "$status" -eq 0 ]
+  [ "$output" = '"kage-0.3.3"' ]
+}
+
+@test "packages.kage resolves on x86_64-linux" {
+  run nix eval --json "path:${FLAKE}#packages.x86_64-linux.kage.name"
+  [ "$status" -eq 0 ]
+  [ "$output" = '"kage-0.3.3"' ]
+}
+
+@test "packages.kage uses go_1_26 from unstable" {
+  run nix eval --json "path:${FLAKE}#packages.aarch64-darwin.kage.go.version"
+  [ "$status" -eq 0 ]
+  # Should be 1.26.x from nixpkgs-unstable
+  [[ "$output" =~ 1\.26\. ]]
+}
+
+@test "packages.kage is a buildGoModule derivation" {
+  # Verify it's a proper Go package by checking the builder
+  run nix eval --json "path:${FLAKE}#packages.aarch64-darwin.kage.pname"
+  [ "$status" -eq 0 ]
+  [ "$output" = '"kage"' ]
+}
+
+# ---------------------------------------------------------------------------
+# Overlay wiring
+# ---------------------------------------------------------------------------
+
+@test "overlays output exposes additions" {
+  run nix eval --json "path:${FLAKE}#overlays.additions" --apply 'x: builtins.typeOf x'
+  [ "$status" -eq 0 ]
+  [ "$output" = '"lambda"' ]
+}
+
+@test "overlays output exposes additionsUnstable" {
+  run nix eval --json "path:${FLAKE}#overlays.additionsUnstable" --apply 'x: builtins.typeOf x'
+  [ "$status" -eq 0 ]
+  [ "$output" = '"lambda"' ]
+}
+
+@test "overlay additionsUnstable makes kage available in pkgs" {
+  run nix eval --impure --expr '
+    let
+      flake = builtins.getFlake "'"${FLAKE}"'";
+      pkgs = flake.inputs.nixpkgs.legacyPackages.aarch64-darwin;
+      pkgsUnstable = flake.inputs.nixpkgs-unstable.legacyPackages.aarch64-darwin;
+      pkgsWithKage = pkgs.extend (flake.outputs.overlays.additionsUnstable pkgsUnstable);
+    in
+      pkgsWithKage.kage.name
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '"kage-0.3.3"' ]
+}
+
+@test "overlay additionsUnstable passes unstable Go to kage" {
+  run nix eval --impure --expr '
+    let
+      flake = builtins.getFlake "'"${FLAKE}"'";
+      pkgs = flake.inputs.nixpkgs.legacyPackages.aarch64-darwin;
+      pkgsUnstable = flake.inputs.nixpkgs-unstable.legacyPackages.aarch64-darwin;
+      pkgsWithKage = pkgs.extend (flake.outputs.overlays.additionsUnstable pkgsUnstable);
+    in
+      pkgsWithKage.kage.go.version
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ 1\.26\. ]]
+}
+
+# ---------------------------------------------------------------------------
+# Home-manager integration
+# ---------------------------------------------------------------------------
+
+@test "homeConfigurations evaluate with kage available" {
+  run nix eval --json "path:${FLAKE}#homeConfigurations.\"quang.van.nguyen@Nguyens-MacBook-Pro.local\".pkgs.kage.name"
+  [ "$status" -eq 0 ]
+  [ "$output" = '"kage-0.3.3"' ]
+}
+
+@test "kage meta is well-formed" {
+  run nix eval --json "path:${FLAKE}#packages.aarch64-darwin.kage.meta" \
+    --apply 'm: { license = m.license.spdxId or "missing"; mainProgram = m.mainProgram or "missing"; }'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "MIT" ]]
+  [[ "$output" =~ "kage" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Future-proofing: detect when workaround is no longer needed
+# ---------------------------------------------------------------------------
+
+@test "WORKAROUND: nixpkgs-unstable go is still < 1.26.4" {
+  skip "Remove this test once Go >= 1.26.4 lands in nixpkgs-unstable"
+  run nix eval --impure --expr '
+    let
+      flake = builtins.getFlake "'"${FLAKE}"'";
+      goVer = flake.inputs.nixpkgs-unstable.legacyPackages.aarch64-darwin.go_1_26.version;
+    in
+      builtins.compareVersions goVer "1.26.4"
+  '
+  [ "$output" -lt 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a custom packages infrastructure and the **kage** package — a Go binary that shadows websites for offline viewing.

## Changes

- **pkgs/** — package registry + kage derivation (v0.3.3, built with Go 1.26.3 from nixpkgs-unstable)
- **overlays/** — `additions` and `additionsUnstable` overlays following the nix-config convention
- **flake.nix** — wires the overlay with unstable pkgs, exposes `packages` and `overlays` outputs
- **cli.nix** — adds kage to home.packages
- **tests/pkgs.bats** — 11 evaluation tests for package resolution, overlay wiring, and Go version selection
- **docs/kage.md** — documentation and cleanup steps for when Go 1.26.4 lands

## How it works

kage's go.mod requires go >= 1.26.4, but nixpkgs-unstable has 1.26.3. The derivation patches go.mod down by one patch version — safe because no 1.26.4-specific features are used and go.sum format is identical within 1.26.x.

```
nix build .#kage      # standalone build
pkgs.kage              # in home-manager modules
bats tests/pkgs.bats   # run tests
```