### PR TITLE
chore: remove legacy openssl-1.1.1w package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,7 @@
     # Shared config for nixpkgs imports
     nixpkgsConfig = {
       config.allowUnfree = true;
-      config.permittedInsecurePackages = [
-        "openssl-1.1.1w"
-      ];
+      config.permittedInsecurePackages = [];
     };
 
     overlays = import ./overlays;

--- a/home-manager/modules/core/dev.nix
+++ b/home-manager/modules/core/dev.nix
@@ -16,7 +16,6 @@
     maple-mono.NF-unhinted
     maple-mono.truetype
     mkcert
-    openssl_1_1
     pkg-config
     pkgs-unstable.ansible-lint
     pkgs-unstable.bun


### PR DESCRIPTION
- Remove openssl_1_1 from dev home packages
- Drop permittedInsecurePackages exception for openssl-1.1.1w