### PR TITLE
feat(pkgs): add yomi package and go 1.26.4 compiler

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,11 +3,27 @@
 {
   pkgs,
   pkgsUnstable ? pkgs,
-}: {
-  # kage needs go >= 1.26.4; unstable has 1.26.3 (closest match).
-  # Falls back to pkgs.go_1_25 when pkgsUnstable is not provided.
+}: let
+  # Go 1.26.4 built from source because nixpkgs-unstable only ships 1.26.3.
+  # Needed by kage and yomi which require go >= 1.26.4 in their go.mod / deps.
+  # TODO: remove when nixpkgs-unstable ships go >= 1.26.4.
+  go_1_26_4 =
+    if (pkgsUnstable.go_1_26 or null) != null
+    then
+      pkgsUnstable.go_1_26.overrideAttrs (_old: {
+        version = "1.26.4";
+        src = pkgs.fetchurl {
+          url = "https://go.dev/dl/go1.26.4.src.tar.gz";
+          hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+        };
+      })
+    else pkgs.go_1_25;
+in {
   kage = pkgs.callPackage ./kage.nix {
-    go =
-      pkgsUnstable.go_1_26 or pkgs.go_1_25;
+    go = go_1_26_4;
+  };
+
+  yomi = pkgs.callPackage ./yomi.nix {
+    go = go_1_26_4;
   };
 }

--- a/pkgs/kage.nix
+++ b/pkgs/kage.nix
@@ -28,13 +28,6 @@ rec {
 
   env.CGO_ENABLED = "0";
 
-  # kage requires go >= 1.26.4. nixpkgs-unstable has 1.26.3, so we patch down
-  # one patch version. No go mod tidy needed — go.sum format unchanged within 1.26.x.
-  # TODO: remove this postPatch when nixpkgs-unstable ships go >= 1.26.4.
-  postPatch = ''
-    substituteInPlace go.mod --replace-fail "go 1.26.4" "go 1.26.3"
-  '';
-
   meta = with lib; {
     description = "Shadow any website for offline viewing, with the JavaScript stripped out";
     homepage = "https://github.com/tamnd/kage";

--- a/pkgs/yomi.nix
+++ b/pkgs/yomi.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go,
+}:
+(buildGoModule.override {inherit go;})
+rec {
+  pname = "yomi";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "tamnd";
+    repo = "yomi";
+    rev = "v${version}";
+    hash = "sha256-sbFWfrhxYdh7cG6/WDSc7vpUaK5stym8nrj2rcE77aQ=";
+  };
+
+  vendorHash = "sha256-f+l1D0kGn1fHaOzZHafv08Nr+iAsndY7j7qCh0UVK+8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/tamnd/yomi/cli.Version=${version}"
+  ];
+
+  subPackages = ["cmd/yomi"];
+
+  env.CGO_ENABLED = "0";
+
+  meta = with lib; {
+    description = "Read any web page, or a whole website, into clean Markdown";
+    homepage = "https://github.com/tamnd/yomi";
+    license = licenses.mit;
+    mainProgram = "yomi";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
### Summary

- **Add yomi v0.2.1** — read any web page into clean Markdown, via `buildGoModule`
- **Build go 1.26.4 from source** — nixpkgs-unstable only ships 1.26.3, but yomi and kage require >= 1.26.4
- **Clean up kage** — remove the `postPatch` go.mod workaround now that real Go 1.26.4 is available

### Files

| File | Change |
|---|---|
| `pkgs/yomi.nix` | New package |
| `pkgs/default.nix` | Add `go_1_26_4` override, wire it for kage and yomi |
| `pkgs/kage.nix` | Drop `postPatch` (no longer needed) |

### Verification

- `nix build .#yomi` — builds successfully on aarch64-darwin
- `nix build .#kage` — builds successfully (unchanged output)
- `just check` — all 23 tests pass, both homeConfigurations evaluate