### PR TITLE
fix(pkgs): resolve kcctl null pointer error on Linux

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,6 @@
-# Custom packages, built via 'nix build .#kage'
-# Also accessible as pkgs.kage in home-manager via the overlay in ../overlays
+# Custom packages: kage, kcctl, yomi
+# Built via 'nix build .#<name>' or accessed as pkgs.<name> in home-manager
+# via the overlay in ../overlays
 {
   pkgs,
   pkgsUnstable ? pkgs,

--- a/pkgs/kcctl.nix
+++ b/pkgs/kcctl.nix
@@ -36,7 +36,6 @@ in
 
     buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
       zlib
-      stdenvNoCC.cc.cc.lib
     ];
 
     sourceRoot = ".";


### PR DESCRIPTION
## Summary

- Fix `kcctl` failing on Linux with `expected a set but found null: null`
- Remove `stdenvNoCC.cc.cc.lib` from buildInputs — `stdenvNoCC` has no C compiler (`cc = null`), so accessing `.cc.lib` throws at evaluation time
- The pre-built kcctl binary only needs `zlib` for `autoPatchelfHook`
- Update comment in `pkgs/default.nix` to list all three custom packages (kage, kcctl, yomi)

## Verification

- `nix eval .#homeConfigurations."xluffy-zzbot@elbaf-sky-n100".activationPackage.name` → passes
- `nix eval .#homeConfigurations."quang.van.nguyen@Nguyens-MacBook-Pro.local".activationPackage.name` → passes