### PR TITLE
refactor: remove adhoc Go 1.26.4 build for kage/yomi

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,29 +4,14 @@
 {
   pkgs,
   pkgsUnstable ? pkgs,
-}: let
-  # Go 1.26.4 built from source because nixpkgs-unstable only ships 1.26.3.
-  # Needed by kage and yomi which require go >= 1.26.4 in their go.mod / deps.
-  # TODO: remove when nixpkgs-unstable ships go >= 1.26.4.
-  go_1_26_4 =
-    if (pkgsUnstable.go_1_26 or null) != null
-    then
-      pkgsUnstable.go_1_26.overrideAttrs (_old: {
-        version = "1.26.4";
-        src = pkgs.fetchurl {
-          url = "https://go.dev/dl/go1.26.4.src.tar.gz";
-          hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
-        };
-      })
-    else pkgs.go_1_25;
-in {
+}: {
   kage = pkgs.callPackage ./kage.nix {
-    go = go_1_26_4;
+    go = pkgsUnstable.go_1_26;
   };
 
   kcctl = pkgs.callPackage ./kcctl.nix {};
 
   yomi = pkgs.callPackage ./yomi.nix {
-    go = go_1_26_4;
+    go = pkgsUnstable.go_1_26;
   };
 }

--- a/tests/pkgs.bats
+++ b/tests/pkgs.bats
@@ -99,18 +99,4 @@ setup() {
   [[ "$output" =~ "kage" ]]
 }
 
-# ---------------------------------------------------------------------------
-# Future-proofing: detect when workaround is no longer needed
-# ---------------------------------------------------------------------------
 
-@test "WORKAROUND: nixpkgs-unstable go is still < 1.26.4" {
-  skip "Remove this test once Go >= 1.26.4 lands in nixpkgs-unstable"
-  run nix eval --impure --expr '
-    let
-      flake = builtins.getFlake "'"${FLAKE}"'";
-      goVer = flake.inputs.nixpkgs-unstable.legacyPackages.aarch64-darwin.go_1_26.version;
-    in
-      builtins.compareVersions goVer "1.26.4"
-  '
-  [ "$output" -lt 0 ]
-}


### PR DESCRIPTION
- Drop the `go_1_26_4` adhoc override in `pkgs/default.nix` since nixpkgs-unstable now ships Go 1.26.4 natively (`pkgsUnstable.go_1_26`).
- Remove the now-unnecessary WORKAROUND test from `tests/pkgs.bats`.