### PR TITLE
feat(pi): enhance grill-me prompt with URL support and shared understanding focus

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778446047,
-        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782366663,
-        "narHash": "sha256-hcxEl/eWQQaYkUqygP4ca8S7WlX9c6vqgvQCqtV3vuw=",
+        "lastModified": 1782981686,
+        "narHash": "sha256-+u0g5NKXt67e4MxX2hvECg0ArGRbtCJPgbH8tuTNraw=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "5f9d86061f538b3f5f3568583c001fb9c0705b71",
+        "rev": "cb156ebf811904005c136ca42a467a6f12de6cb8",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782030356,
-        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
+        "lastModified": 1782636943,
+        "narHash": "sha256-ripjZa7BBLwL1uS5VJF3s/VpZpWt5ZIQEvkJ/FJNpQw=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
+        "rev": "058b1f9381fa79fcda49982370a750ff92dbba43",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782118813,
-        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
+        "lastModified": 1782888527,
+        "narHash": "sha256-ry+llIN/SGgvPrvHaGaXb/tOHfTWtkmspDu28pgsitc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
+        "rev": "f76e4c7b1840704deda511ab34f37b829f6b5636",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {

--- a/home-manager/config/pi/prompts/grill-me.md
+++ b/home-manager/config/pi/prompts/grill-me.md
@@ -15,7 +15,7 @@ ${@:2}
 
 The goal of this session is **we reach a shared understanding**. This is not a quiz, not a rubber-duck session, and not a lecture. I stop only when both I and the user genuinely agree on every decision, every tradeoff, and every open question. "I don't know yet" is an acceptable intermediate state -- but the session is not over until we collectively reach clarity.
 
-If the user gives a vague or hand-wavy answer, push back. If the user changes their mind mid-way, explore the new direction fully. If we hit a dead end, backtrack and find another path. "Shared understanding" means the user can explain the decision back to me, and I can explain the reasoning back to them.
+If something sounds vague, I'll ask for more detail. If you change direction mid-way, cool -- let's explore the new path fully. If we hit a wall, we backtrack and try another angle.
 
 ## Input handling
 
@@ -23,18 +23,17 @@ If the user gives a vague or hand-wavy answer, push back. If the user changes th
 - If $1 is a file path: read it directly.
 - Always process the first argument first. It is the primary document to grill on.
 
-## Deep scan additional context
+## Digging into extra context
 
 For every additional argument ($2, $3, ...):
 - If it's a URL, use `yomi read` to fetch it.
 - If it's a file path, read it.
-- Cross-reference these sources with the primary document.
-- Use contradictions, gaps, or hidden assumptions between sources to ask harder, more pointed questions.
-- When providing your recommended answer, cite specific evidence from the additional context.
+- I'll cross-check these with the main doc and use any contradictions, gaps, or hidden assumptions to ask sharper, more pointed questions.
+- When I suggest an answer, I'll point to specific evidence from the extra context.
 
 ## Interview method
 
-Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer with reasoning.
+Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide a few your recommended answer with reasoning.
 
 Ask the questions one at a time.
 

--- a/home-manager/config/pi/prompts/grill-me.md
+++ b/home-manager/config/pi/prompts/grill-me.md
@@ -1,17 +1,45 @@
 ---
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+description: Interview the user relentlessly until we reach a shared understanding. Deep scans additional context files for harder questions. Use when you need to stress-test a plan, spec, design, runbook, or any markdown document.
 adapted-from: https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
 author: Matt Pocock (mattpocock)
+argument-hint: "<file-or-URL> [additional-context...]"
 ---
 
-Your task:
+Your task: $1
 
-$ARGUMENTS
+Additional context:
+
+${@:2}
 
 ---
 
-Interview me relentlessly about this topic until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+The goal of this session is **we reach a shared understanding**. This is not a quiz, not a rubber-duck session, and not a lecture. I stop only when both I and the user genuinely agree on every decision, every tradeoff, and every open question. "I don't know yet" is an acceptable intermediate state -- but the session is not over until we collectively reach clarity.
+
+If the user gives a vague or hand-wavy answer, push back. If the user changes their mind mid-way, explore the new direction fully. If we hit a dead end, backtrack and find another path. "Shared understanding" means the user can explain the decision back to me, and I can explain the reasoning back to them.
+
+## Input handling
+
+- If $1 is a URL: first use `yomi read <URL>` to fetch and convert it to Markdown.
+- If $1 is a file path: read it directly.
+- Always process the first argument first. It is the primary document to grill on.
+
+## Deep scan additional context
+
+For every additional argument ($2, $3, ...):
+- If it's a URL, use `yomi read` to fetch it.
+- If it's a file path, read it.
+- Cross-reference these sources with the primary document.
+- Use contradictions, gaps, or hidden assumptions between sources to ask harder, more pointed questions.
+- When providing your recommended answer, cite specific evidence from the additional context.
+
+## Interview method
+
+Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer with reasoning.
 
 Ask the questions one at a time.
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+**Do not move on until we reach a shared understanding on the current decision.** The user's confirmation must be explicit -- "yes", "agreed", "makes sense", or rephrasing the decision in their own words. Nodding along ("ok", "sure", "go on") is not enough.
+
+At the end of the session, summarize every decision we resolved and every open question we identified. Confirm one final time: **have we reached a shared understanding?** If not, loop back.


### PR DESCRIPTION
## Summary

Enhance the `/grill-me` prompt template with:

- **URL support**: First argument can be a URL — the model uses `yomi read` to fetch it
- **Additional context**: Extra arguments are deeply scanned and cross-referenced for harder questions
- **Shared understanding**: Stronger enforcement with explicit confirmation requirements and a closing loop

### Changes

- `home-manager/config/pi/prompts/grill-me.md` — full rewrite with structured sections (Input handling, Deep scan, Interview method)
