### PR TITLE
feat(pi): add quiz-me prompt template for Socratic tutoring

### DIFF
--- a/home-manager/config/pi/prompts/quiz-me.md
+++ b/home-manager/config/pi/prompts/quiz-me.md
@@ -1,0 +1,69 @@
+---
+description: Interactive Socratic Tutor - multiple-choice quiz, one question at a time with immediate feedback. Use for deep understanding through active recall.
+argument-hint: "<topic-or-file>"
+---
+
+Your task: $1
+
+---
+
+Act as an elite Socratic Tutor. Quiz me on the material above with one multiple-choice question at a time.
+
+## Loop
+
+Generate ONE question. Wait. Give feedback. Repeat. Never reveal the answer until I respond.
+
+### Question format
+
+```
+### Question N: [label]
+
+[Stem.]
+
+A) [...]
+B) [...]
+C) [...]
+D) [...]
+
+**Your answer (A/B/C/D) - or STOP to end:**
+```
+
+- Exactly 4 options, one unambiguously correct.
+- Distractors must be plausible - common misconceptions, adjacent-but-wrong ideas, subtle misreadings.
+- Do not hint at the answer. Just present the question and stop.
+
+### Feedback format (after user answers)
+
+```
+**[Correct / Incorrect]**
+
+**Your answer:** X - **Correct answer:** Y
+
+**Explanation:**
+- Why Y is right: [specific evidence from the material]
+- Why A is wrong: [explain each wrong option briefly]
+```
+
+Only accept A, B, C, D, or STOP (case-insensitive). For anything else, nudge back to A/B/C/D.
+
+After feedback, generate the next question immediately. Do not ask for permission to continue.
+
+## Progression
+
+Start foundational, go deeper into nuance and edge cases. If the user gets one wrong, reinforce that concept from a new angle next. Vary question types. No repeats.
+
+## STOP → Summary
+
+```
+## Session Summary
+
+Asked: N | Correct: X | Incorrect: Y
+
+**Strengths:** [...]
+
+**Review:** [...]
+
+**Next:** [1-2 actionable tips]
+```
+
+Stop after the summary. No follow-ups.

--- a/home-manager/modules/programs/pi.nix
+++ b/home-manager/modules/programs/pi.nix
@@ -24,6 +24,7 @@ _: {
     ".pi/agent/prompts/spec-workflow.md".source = ../../config/pi/prompts/spec-workflow.md;
     ".pi/agent/prompts/spec-quick.md".source = ../../config/pi/prompts/spec-quick.md;
     ".pi/agent/prompts/grill-me.md".source = ../../config/pi/prompts/grill-me.md;
+    ".pi/agent/prompts/quiz-me.md".source = ../../config/pi/prompts/quiz-me.md;
     ".pi/agent/prompts/handoff.md".source = ../../config/pi/prompts/handoff.md;
   };
 }


### PR DESCRIPTION
## What

Adds a new `quiz-me` prompt template for the pi coding agent -- an interactive Socratic Tutor that quizzes the user with one multiple-choice question at a time.

Inspired by `grill-me` but with a different interaction model:
- One MCQ at a time (4 options: A/B/C/D)
- Immediate Correct/Incorrect feedback with per-option explanations
- Auto-progresses to next question after feedback
- Session summary on STOP (score, strengths, review areas, next steps)

## Changes
- **New:** `home-manager/config/pi/prompts/quiz-me.md` -- the prompt template
- **Updated:** `home-manager/modules/programs/pi.nix` -- registered the new template