### PR TITLE
chore: upgrade nixpkgs and home-manager to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,16 +152,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1763992789,
-        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
+        "lastModified": 1783221248,
+        "narHash": "sha256-ESQnuNHEDChsB4IxoLRhscVahqkDWkTb+qdIz8euYt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
+        "rev": "af2beae5f0fae0a4310cc0e6aef2572f56090353",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -243,16 +243,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1783148766,
+        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,12 @@
   description = "Home manager configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     llm-agents.url = "github:numtide/llm-agents.nix";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.05";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/home-manager/modules/core/dev.nix
+++ b/home-manager/modules/core/dev.nix
@@ -25,7 +25,7 @@
     pkgs-unstable.node-gyp
     pkgs-unstable.nodejs_24
     prometheus.cli
-    python310
+    python313
     regal
     rustc
     rustup

--- a/home-manager/modules/core/nix.nix
+++ b/home-manager/modules/core/nix.nix
@@ -3,7 +3,7 @@
     alejandra
     deadnix
     nix-tree
-    nixfmt-rfc-style
+    nixfmt
     statix
   ];
 }

--- a/home-manager/modules/programs/git.nix
+++ b/home-manager/modules/programs/git.nix
@@ -8,9 +8,6 @@
       enable = true;
       lfs.enable = true;
 
-      userEmail = "quang@2meo.com";
-      userName = "xluffy";
-
       includes = [
         {
           condition = "gitdir:~/code/me/";
@@ -36,20 +33,41 @@
         }
       ];
 
-      aliases = {
-        a = "add";
-        p = "push";
-        pul = "pull";
-        ci = "commit -S";
-        st = "status -uno";
-        stt = "status";
-        co = "checkout";
-        br = "branch";
-        lol = "log --graph --decorate --pretty=oneline --abbrev-commit";
-        lola = "log --graph --decorate --pretty=oneline --abbrev-commit --all";
-      };
+      ignores = [
+        ".DS_Store"
+        ".env"
+        "__pycache__"
+        ".terraform"
+        "terraform.tfvars"
+        "*.key"
+        "*.pem"
+        "*.crt"
+        ".vault_*"
+      ];
 
-      extraConfig = {
+      settings = {
+        user = {
+          email = "quang@2meo.com";
+          name = "xluffy";
+          signingkey =
+            if pkgs.stdenv.isDarwin
+            then "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6gzw6c40c8zowzZ6nR8iRwsYy0qg2sNvro09nFtTzF"
+            else "${config.custom.ssh.identityFile}.pub";
+        };
+
+        alias = {
+          a = "add";
+          p = "push";
+          pul = "pull";
+          ci = "commit -S";
+          st = "status -uno";
+          stt = "status";
+          co = "checkout";
+          br = "branch";
+          lol = "log --graph --decorate --pretty=oneline --abbrev-commit";
+          lola = "log --graph --decorate --pretty=oneline --abbrev-commit --all";
+        };
+
         color = {
           branch = "auto";
           diff = "auto";
@@ -103,34 +121,17 @@
           };
         };
 
-        user = {
-          signingkey =
-            if pkgs.stdenv.isDarwin
-            then "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6gzw6c40c8zowzZ6nR8iRwsYy0qg2sNvro09nFtTzF"
-            else "${config.custom.ssh.identityFile}.pub";
-        };
         lfs."customtransfer.xet" = {
           path = "git-xet";
           args = "transfer";
           concurrent = true;
         };
       };
+    };
 
-      diff-so-fancy = {
-        enable = true;
-      };
-
-      ignores = [
-        ".DS_Store"
-        ".env"
-        "__pycache__"
-        ".terraform"
-        "terraform.tfvars"
-        "*.key"
-        "*.pem"
-        "*.crt"
-        ".vault_*"
-      ];
+    diff-so-fancy = {
+      enable = true;
+      enableGitIntegration = true;
     };
   };
 }

--- a/home-manager/modules/programs/ssh.nix
+++ b/home-manager/modules/programs/ssh.nix
@@ -25,7 +25,8 @@ in {
     # Client side SSH configuratio
     programs.ssh = {
       enable = true;
-      compression = true;
+      enableDefaultConfig = false;
+      settings."*".Compression = true;
     };
 
     home.file.".ssh/config".text = ''


### PR DESCRIPTION
## Summary

- Bump nixpkgs to nixos-26.05 and home-manager to release-26.05
- Migrate deprecated git options (userEmail/userName/aliases/extraConfig) to programs.git.settings
- Move diff-so-fancy to standalone programs.diff-so-fancy, ssh compression to settings.*.Compression
- Replace removed packages: python310 -> python313, nixfmt-rfc-style -> nixfmt