### PR TITLE
docs: remove prose semicolons to comply with APPEND_SYSTEM.md policy

### DIFF
--- a/home-manager/config/pi/prompts/git-ci.md
+++ b/home-manager/config/pi/prompts/git-ci.md
@@ -16,10 +16,10 @@ Commit Types
 - `feat`: A new feature for the user, not a new feature for builds.
 - `fix`: A bug fix for the user, not a fix for a build script.
 - `docs`: Changes to the documentation.
-- `style`: Formatting, missing semi-colons, etc.; no production code change.
+- `style`: Formatting, missing semi-colons, etc. No production code change.
 - `refactor`: Refactoring production code, e.g. renaming a variable.
 - `perf`: Code changes that improve performance.
-- `test`: Adding missing tests, refactoring tests; no production code change.
+- `test`: Adding missing tests, refactoring tests. No production code change.
 - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
 - `ci`: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).
 - `chore`: Other changes that don't modify src or test files.

--- a/home-manager/config/pi/skills/bash-scripting/SKILL.md
+++ b/home-manager/config/pi/skills/bash-scripting/SKILL.md
@@ -62,7 +62,7 @@ set -uo pipefail
 - `-u` - reject undefined variables (catches typos early)
 - `-o pipefail` - a pipeline fails if *any* command in it fails
 
-**Do not use `set -e`** (errexit). It has surprising edge cases: it does not trigger inside `(( ))` evaluating to 0, inside `let`, or when a failing command is the condition of `if`/`while`/`||`/`&&`. It also turns off inside subshells. Explicit error checks are predictable; `set -e` is not.
+**Do not use `set -e`** (errexit). It has surprising edge cases: it does not trigger inside `(( ))` evaluating to 0, inside `let`, or when a failing command is the condition of `if`/`while`/`||`/`&&`. It also turns off inside subshells. Explicit error checks are predictable. `set -e` is not.
 
 Use `set -x` for interactive debugging only. Do not commit it.
 
@@ -570,7 +570,7 @@ _die() {
 ```
 
 Key points:
-- `_log` writes to stdout; `_die` writes to stderr with `>&2`
+- `_log` writes to stdout. `_die` writes to stderr with `>&2`
 - Use `printf`, not `echo` - `echo` varies across shells with `-n`, `-e`, backslashes
 - `%()T` with `-1` is bash builtin `printf` time formatting - avoids a `date` subshell
 

--- a/home-manager/config/pi/skills/laravel-best-practices/SKILL.md
+++ b/home-manager/config/pi/skills/laravel-best-practices/SKILL.md
@@ -72,7 +72,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 6. Validation & Forms → `rules/validation.md`
 
 - Form Request classes, not inline validation
-- Array notation `['required', 'email']` for new code; follow existing convention
+- Array notation `['required', 'email']` for new code. Follow existing convention
 - `$request->validated()` only - never `$request->all()`
 - `Rule::when()` for conditional validation
 - `after()` instead of `withValidator()`
@@ -93,10 +93,10 @@ Check sibling files, related controllers, models, or tests for established patte
 
 ### 9. Queue & Job Patterns → `rules/queue-jobs.md`
 
-- `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
-- Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
-- `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
+- `retry_after` must exceed job `timeout`. Use exponential backoff `[1, 5, 10]`
+- `ShouldBeUnique` to prevent duplicates. `ShouldBeUniqueUntilProcessing` for early lock release
+- Always implement `failed()`. With `retryUntil()`, set `$tries = 0`
+- `RateLimited` middleware for external API calls. `Bus::batch()` for related jobs
 - Horizon for complex multi-queue scenarios
 
 ### 10. Routing & Controllers → `rules/routing.md`
@@ -117,7 +117,7 @@ Check sibling files, related controllers, models, or tests for established patte
 
 ### 12. Events, Notifications & Mail → `rules/events-notifications.md`, `rules/mail.md`
 
-- Event discovery over manual registration; `event:cache` in production
+- Event discovery over manual registration. `event:cache` in production
 - `ShouldDispatchAfterCommit` / `afterCommit()` inside transactions
 - Queue notifications and mailables with `ShouldQueue`
 - On-demand notifications for non-user recipients
@@ -145,10 +145,10 @@ Check sibling files, related controllers, models, or tests for established patte
 
 ### 15. Architecture → `rules/architecture.md`
 
-- Single-purpose Action classes; dependency injection over `app()` helper
+- Single-purpose Action classes. Dependency injection over `app()` helper
 - Prefer official Laravel packages and follow conventions, don't override defaults
-- Default to `ORDER BY id DESC` or `created_at DESC`; `mb_*` for UTF-8 safety
-- `defer()` for post-response work; `Context` for request-scoped data; `Concurrency::run()` for parallel execution
+- Default to `ORDER BY id DESC` or `created_at DESC`. `mb_*` for UTF-8 safety
+- `defer()` for post-response work. `Context` for request-scoped data. `Concurrency::run()` for parallel execution
 
 ### 16. Migrations → `rules/migrations.md`
 
@@ -157,7 +157,7 @@ Check sibling files, related controllers, models, or tests for established patte
 - Never modify migrations that have run in production
 - Add indexes in the migration, not as an afterthought
 - Mirror column defaults in model `$attributes`
-- Reversible `down()` by default; forward-fix migrations for intentionally irreversible changes
+- Reversible `down()` by default. Forward-fix migrations for intentionally irreversible changes
 - One concern per migration - never mix DDL and DML
 
 ### 17. Collections → `rules/collections.md`
@@ -170,7 +170,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 18. Blade & Views → `rules/blade-views.md`
 
 - `$attributes->merge()` in component templates
-- Blade components over `@include`; `@pushOnce` for per-component scripts
+- Blade components over `@include`. `@pushOnce` for per-component scripts
 - View Composers for shared view data
 - `@aware` for deeply nested component props
 
@@ -179,7 +179,7 @@ Check sibling files, related controllers, models, or tests for established patte
 - Follow Laravel naming conventions for all entities
 - Prefer Laravel helpers (`Str`, `Arr`, `Number`, `Uri`, `Str::of()`, `$request->string()`) over raw PHP functions
 - No JS/CSS in Blade, no HTML in PHP classes
-- Code should be readable; comments only for config files
+- Code should be readable. Comments only for config files
 
 ## How to Apply
 

--- a/home-manager/config/pi/skills/laravel-helper/SKILL.md
+++ b/home-manager/config/pi/skills/laravel-helper/SKILL.md
@@ -41,7 +41,7 @@ Prefer these language features over older equivalents:
       ) {}
   }
   ```
-- **Match expressions** - Replace long `switch` chains; `match` is exhaustive.
+- **Match expressions** - Replace long `switch` chains. `match` is exhaustive.
 - **Named arguments** - Use when calling methods with many optional/default params.
 - **First-class callable syntax** - `$this->method(...)` instead of `[$this, 'method']`.
 - **Array unpacking with string keys** - `[...$array1, ...$array2]`.
@@ -53,7 +53,7 @@ Prefer these language features over older equivalents:
   ```bash
   ./vendor/bin/pint
   ```
-- Run Pint before committing; configure IDE format-on-save.
+- Run Pint before committing. Configure IDE format-on-save.
 - For inspections and static analysis, use **Larastan** (level 5+):
   ```bash
   ./vendor/bin/phpstan analyse
@@ -159,7 +159,7 @@ app/
   ```
 - For resource controllers with 4+ standard methods, group related ones.
 - Use **route model binding** with explicit binding in `RouteServiceProvider` for non-id keys.
-- Return API Resources from API routes; return views from web routes.
+- Return API Resources from API routes. Return views from web routes.
 - Handle authorization via Policies + FormRequests (first line of controller/request).
 
 ## Routing
@@ -167,7 +167,7 @@ app/
 - Use `Route::apiResource()` for RESTful APIs.
 - Name all routes with `.name()` or prefixes: `Route::name('admin.')->group(...)`.
 - Group middleware, prefixes, and namespaces explicitly.
-- Use `Route::controller()` sparingly; prefer explicit method referencing.
+- Use `Route::controller()` sparingly. Prefer explicit method referencing.
 - In `routes/api.php`, keep the default `api` prefix and `auth:sanctum` middleware.
 
 ## Validation
@@ -247,9 +247,9 @@ app/
 ## Migration Conventions
 
 - Use `$table->foreignIdFor(User::class)->constrained()` over verbose `$table->foreignId('user_id')`.
-- Add `->cascadeOnDelete()` or `->restrictOnDelete()` explicitly; don't rely on DB defaults.
+- Add `->cascadeOnDelete()` or `->restrictOnDelete()` explicitly. Don't rely on DB defaults.
 - For large tables, use batches in `down()` methods for reversibility.
-- Never import `DB` facade in migrations; use the `$table` builder.
+- Never import `DB` facade in migrations. Use the `$table` builder.
 
 ## Service Provider Conventions
 
@@ -261,7 +261,7 @@ app/
 ## Queue & Jobs
 
 - Jobs should implement `ShouldQueue` and `ShouldBeUnique` where applicable.
-- Use `dispatch()` helper or `Bus::dispatch()`; avoid `dispatchNow()`.
+- Use `dispatch()` helper or `Bus::dispatch()`. Avoid `dispatchNow()`.
 - Set `$timeout`, `$tries`, `backoff()` explicitly.
 - Handle failures gracefully with `failed()` method or `JobFailed` event listener.
 - Prefer dedicated `Job` classes over inline closures in `dispatch(fn () => ...)`.
@@ -301,6 +301,6 @@ app/
 
 - Use `strip_tags()` on user-generated content BEFORE storing (in FormRequest `passedValidation()`).
 - Use Blade `{{ }}` (auto-escaped) for output. Never use `{!! !!}` with user input.
-- Mass-assign via `$fillable` only; never use `request()->all()` to create/update models.
+- Mass-assign via `$fillable` only. Never use `request()->all()` to create/update models.
 - For rate limiting, use `RateLimiter` facade in RouteServiceProvider or middleware.
 - Sign sensitive URLs with `URL::signedRoute()` and `URL::temporarySignedRoute()`.


### PR DESCRIPTION
## Summary
Replace prose semicolons with sentence breaks in pi prompt templates and skill files to comply with APPEND_SYSTEM.md policy.

## Files changed
- **prompts/git-ci.md** - 2 prose semicolons replaced
- **skills/bash-scripting/SKILL.md** - 2 prose semicolons replaced
- **skills/laravel-helper/SKILL.md** - 8 prose semicolons replaced
- **skills/laravel-best-practices/SKILL.md** - 8 prose semicolons replaced

No code blocks or syntax semicolons were touched.