### PR TITLE
feat(neovim): add AstroVim v6 as Home Manager-managed config

### DIFF
--- a/home-manager/config/nvim/.luarc.json
+++ b/home-manager/config/nvim/.luarc.json
@@ -1,0 +1,3 @@
+{
+  "format.enable": false
+}

--- a/home-manager/config/nvim/.neoconf.json
+++ b/home-manager/config/nvim/.neoconf.json
@@ -1,0 +1,20 @@
+{
+  "neodev": {
+    "library": {
+      "enabled": true,
+      "plugins": true
+    }
+  },
+  "neoconf": {
+    "plugins": {
+      "lua_ls": {
+        "enabled": true
+      }
+    }
+  },
+  "lspconfig": {
+    "lua_ls": {
+      "Lua.format.enable": false
+    }
+  }
+}

--- a/home-manager/config/nvim/.stylua.toml
+++ b/home-manager/config/nvim/.stylua.toml
@@ -1,0 +1,7 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "None"
+collapse_simple_statement = "Always"

--- a/home-manager/config/nvim/init.lua
+++ b/home-manager/config/nvim/init.lua
@@ -1,0 +1,27 @@
+-- This file simply bootstraps the installation of Lazy.nvim and then calls other files for execution
+-- This file doesn't necessarily need to be touched, BE CAUTIOUS editing this file and proceed at your own risk.
+local lazypath = vim.env.LAZY or vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
+
+if not (vim.env.LAZY or (vim.uv or vim.loop).fs_stat(lazypath)) then
+  -- stylua: ignore
+  local result = vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
+  if vim.v.shell_error ~= 0 then
+    -- stylua: ignore
+    vim.api.nvim_echo({ { ("Error cloning lazy.nvim:\n%s\n"):format(result), "ErrorMsg" }, { "Press any key to exit...", "MoreMsg" } }, true, {})
+    vim.fn.getchar()
+    vim.cmd.quit()
+  end
+end
+
+vim.opt.rtp:prepend(lazypath)
+
+-- validate that lazy is available
+if not pcall(require, "lazy") then
+  -- stylua: ignore
+  vim.api.nvim_echo({ { ("Unable to load lazy from: %s\n"):format(lazypath), "ErrorMsg" }, { "Press any key to exit...", "MoreMsg" } }, true, {})
+  vim.fn.getchar()
+  vim.cmd.quit()
+end
+
+require "lazy_setup"
+require "polish"

--- a/home-manager/config/nvim/lua/community.lua
+++ b/home-manager/config/nvim/lua/community.lua
@@ -1,0 +1,12 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- AstroCommunity: import any community modules here
+-- We import this file in `lazy_setup.lua` before the `plugins/` folder.
+-- This guarantees that the specs are processed before any user plugins.
+
+---@type LazySpec
+return {
+  "AstroNvim/astrocommunity",
+  { import = "astrocommunity.pack.lua" },
+  -- import/override with your plugins folder
+}

--- a/home-manager/config/nvim/lua/community.lua
+++ b/home-manager/config/nvim/lua/community.lua
@@ -1,12 +1,21 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
-
--- AstroCommunity: import any community modules here
--- We import this file in `lazy_setup.lua` before the `plugins/` folder.
--- This guarantees that the specs are processed before any user plugins.
-
----@type LazySpec
 return {
   "AstroNvim/astrocommunity",
-  { import = "astrocommunity.pack.lua" },
-  -- import/override with your plugins folder
+
+  -- language packs: treesitter + LSP + formatting
+  { import = "astrocommunity.pack.bash" },
+  { import = "astrocommunity.pack.go" },
+  { import = "astrocommunity.pack.markdown" },
+  { import = "astrocommunity.pack.nix" },
+  { import = "astrocommunity.pack.php" },
+  { import = "astrocommunity.pack.python" },
+  { import = "astrocommunity.pack.rust" },
+  { import = "astrocommunity.pack.terraform" },
+  { import = "astrocommunity.pack.typescript" },
+
+  -- colorscheme
+  { import = "astrocommunity.colorscheme.dracula-nvim" },
+  { import = "astrocommunity.colorscheme.nord-nvim" },
+
+  -- window management
+  { import = "astrocommunity.split-and-window.windows-nvim" },
 }

--- a/home-manager/config/nvim/lua/config/autocmds.lua
+++ b/home-manager/config/nvim/lua/config/autocmds.lua
@@ -1,0 +1,4 @@
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "gohtmltmpl",
+  callback = function() vim.treesitter.start(0, "gotmpl") end,
+})

--- a/home-manager/config/nvim/lua/config/autocmds.lua
+++ b/home-manager/config/nvim/lua/config/autocmds.lua
@@ -1,4 +1,0 @@
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = "gohtmltmpl",
-  callback = function() vim.treesitter.start(0, "gotmpl") end,
-})

--- a/home-manager/config/nvim/lua/lazy_setup.lua
+++ b/home-manager/config/nvim/lua/lazy_setup.lua
@@ -1,0 +1,33 @@
+require("lazy").setup({
+  {
+    "AstroNvim/AstroNvim",
+    version = "^6", -- Remove version tracking to elect for nightly AstroNvim
+    import = "astronvim.plugins",
+    opts = { -- AstroNvim options must be set here with the `import` key
+      mapleader = " ", -- This ensures the leader key must be configured before Lazy is set up
+      maplocalleader = ",", -- This ensures the localleader key must be configured before Lazy is set up
+      icons_enabled = true, -- Set to false to disable icons (if no Nerd Font is available)
+      pin_plugins = nil, -- Default will pin plugins when tracking `version` of AstroNvim, set to true/false to override
+      update_notifications = true, -- Enable/disable notification about running `:Lazy update` twice to update pinned plugins
+    },
+  },
+  { import = "community" },
+  { import = "plugins" },
+} --[[@as LazySpec]], {
+  -- Configure any other `lazy.nvim` configuration options here
+  lockfile = vim.fn.stdpath("state") .. "/lazy-lock.json", -- keep lockfile out of config dir (not tracked by git)
+  install = { colorscheme = { "astrotheme", "habamax" } },
+  ui = { backdrop = 100 },
+  performance = {
+    rtp = {
+      -- disable some rtp plugins, add more to your liking
+      disabled_plugins = {
+        "gzip",
+        "netrwPlugin",
+        "tarPlugin",
+        "tohtml",
+        "zipPlugin",
+      },
+    },
+  },
+} --[[@as LazyConfig]])

--- a/home-manager/config/nvim/lua/options.lua
+++ b/home-manager/config/nvim/lua/options.lua
@@ -1,0 +1,2 @@
+vim.o.grepprg = "rg --vimgrep --smart-case --hidden"
+vim.o.grepformat = "%f:%l:%c:%m"

--- a/home-manager/config/nvim/lua/plugins/aerial.lua
+++ b/home-manager/config/nvim/lua/plugins/aerial.lua
@@ -1,0 +1,6 @@
+return {
+  {
+    "stevearc/aerial.nvim",
+    enabled = false,
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/astrocore.lua
+++ b/home-manager/config/nvim/lua/plugins/astrocore.lua
@@ -1,0 +1,85 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- AstroCore provides a central place to modify mappings, vim options, autocommands, and more!
+-- Configuration documentation can be found with `:h astrocore`
+-- NOTE: We highly recommend setting up the Lua Language Server (`:LspInstall lua_ls`)
+--       as this provides autocomplete and documentation while editing
+
+---@type LazySpec
+return {
+  "AstroNvim/astrocore",
+  ---@type AstroCoreOpts
+  opts = {
+    -- Configure core features of AstroNvim
+    features = {
+      large_buf = { size = 1024 * 256, lines = 10000 }, -- set global limits for large files for disabling features like treesitter
+      autopairs = true, -- enable autopairs at start
+      cmp = true, -- enable completion at start
+      diagnostics = { virtual_text = true, virtual_lines = false }, -- diagnostic settings on startup
+      highlighturl = true, -- highlight URLs at start
+      notifications = true, -- enable notifications at start
+    },
+    -- Diagnostics configuration (for vim.diagnostics.config({...})) when diagnostics are on
+    diagnostics = {
+      virtual_text = true,
+      underline = true,
+    },
+    -- passed to `vim.filetype.add`
+    filetypes = {
+      -- see `:h vim.filetype.add` for usage
+      extension = {
+        foo = "fooscript",
+      },
+      filename = {
+        [".foorc"] = "fooscript",
+      },
+      pattern = {
+        [".*/etc/foo/.*"] = "fooscript",
+      },
+    },
+    -- vim options can be configured here
+    options = {
+      opt = { -- vim.opt.<key>
+        relativenumber = true, -- sets vim.opt.relativenumber
+        number = true, -- sets vim.opt.number
+        spell = false, -- sets vim.opt.spell
+        signcolumn = "yes", -- sets vim.opt.signcolumn to yes
+        wrap = false, -- sets vim.opt.wrap
+      },
+      g = { -- vim.g.<key>
+        -- configure global vim variables (vim.g)
+        -- NOTE: `mapleader` and `maplocalleader` must be set in the AstroNvim opts or before `lazy.setup`
+        -- This can be found in the `lua/lazy_setup.lua` file
+      },
+    },
+    -- Mappings can be configured through AstroCore as well.
+    -- NOTE: keycodes follow the casing in the vimdocs. For example, `<Leader>` must be capitalized
+    mappings = {
+      -- first key is the mode
+      n = {
+        -- second key is the lefthand side of the map
+
+        -- navigate buffer tabs
+        ["]b"] = { function() require("astrocore.buffer").nav(vim.v.count1) end, desc = "Next buffer" },
+        ["[b"] = { function() require("astrocore.buffer").nav(-vim.v.count1) end, desc = "Previous buffer" },
+
+        -- mappings seen under group name "Buffer"
+        ["<Leader>bd"] = {
+          function()
+            require("astroui.status.heirline").buffer_picker(
+              function(bufnr) require("astrocore.buffer").close(bufnr) end
+            )
+          end,
+          desc = "Close buffer from tabline",
+        },
+
+        -- tables with just a `desc` key will be registered with which-key if it's installed
+        -- this is useful for naming menus
+        -- ["<Leader>b"] = { desc = "Buffers" },
+
+        -- setting a mapping to false will disable it
+        -- ["<C-S>"] = false,
+      },
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/astrolsp.lua
+++ b/home-manager/config/nvim/lua/plugins/astrolsp.lua
@@ -1,0 +1,104 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- AstroLSP allows you to customize the features in AstroNvim's LSP configuration engine
+-- Configuration documentation can be found with `:h astrolsp`
+-- NOTE: We highly recommend setting up the Lua Language Server (`:LspInstall lua_ls`)
+--       as this provides autocomplete and documentation while editing
+
+---@type LazySpec
+return {
+  "AstroNvim/astrolsp",
+  ---@type AstroLSPOpts
+  opts = {
+    -- Configuration table of features provided by AstroLSP
+    features = {
+      codelens = true, -- enable/disable codelens refresh on start
+      inlay_hints = false, -- enable/disable inlay hints on start
+      semantic_tokens = true, -- enable/disable semantic token highlighting
+    },
+    -- customize lsp formatting options
+    formatting = {
+      -- control auto formatting on save
+      format_on_save = {
+        enabled = true, -- enable or disable format on save globally
+        allow_filetypes = { -- enable format on save for specified filetypes only
+          -- "go",
+        },
+        ignore_filetypes = { -- disable format on save for specified filetypes
+          -- "python",
+        },
+      },
+      disabled = { -- disable formatting capabilities for the listed language servers
+        -- disable lua_ls formatting capability if you want to use StyLua to format your lua code
+        -- "lua_ls",
+      },
+      timeout_ms = 1000, -- default format timeout
+      -- filter = function(client) -- fully override the default formatting function
+      --   return true
+      -- end
+    },
+    -- enable servers that you already have installed without mason
+    servers = {
+      -- "pyright"
+    },
+    -- customize language server configuration passed to `vim.lsp.config`
+    -- client specific configuration can also go in `lsp/` in your configuration root (see `:h lsp-config`)
+    config = {
+      -- ["*"] = { capabilities = {} }, -- modify default LSP client settings such as capabilities
+    },
+    -- customize how language servers are attached
+    handlers = {
+      -- a function with the key `*` modifies the default handler, functions takes the server name as the parameter
+      -- ["*"] = function(server) vim.lsp.enable(server) end
+
+      -- the key is the server that is being setup with `vim.lsp.config`
+      -- rust_analyzer = false, -- setting a handler to false will disable the set up of that language server
+    },
+    -- Configure buffer local auto commands to add when attaching a language server
+    autocmds = {
+      -- first key is the `augroup` to add the auto commands to (:h augroup)
+      lsp_codelens_refresh = {
+        -- Optional condition to create/delete auto command group
+        -- can either be a string of a client capability or a function of `fun(client, bufnr): boolean`
+        -- condition will be resolved for each client on each execution and if it ever fails for all clients,
+        -- the auto commands will be deleted for that buffer
+        cond = "textDocument/codeLens",
+        -- cond = function(client, bufnr) return client.name == "lua_ls" end,
+        -- list of auto commands to set
+        {
+          -- events to trigger
+          event = { "InsertLeave", "BufEnter" },
+          -- the rest of the autocmd options (:h nvim_create_autocmd)
+          desc = "Refresh codelens (buffer)",
+          callback = function(args)
+            if require("astrolsp").config.features.codelens then vim.lsp.codelens.enable(true, { bufnr = args.buf }) end
+          end,
+        },
+      },
+    },
+    -- mappings to be set up on attaching of a language server
+    mappings = {
+      n = {
+        -- a `cond` key can provided as the string of a server capability to be required to attach, or a function with `client` and `bufnr` parameters from the `on_attach` that returns a boolean
+        gD = {
+          function() vim.lsp.buf.declaration() end,
+          desc = "Declaration of current symbol",
+          cond = "textDocument/declaration",
+        },
+        ["<Leader>uY"] = {
+          function() require("astrolsp.toggles").buffer_semantic_tokens() end,
+          desc = "Toggle LSP semantic highlight (buffer)",
+          cond = function(client)
+            return client:supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens ~= nil
+          end,
+        },
+      },
+    },
+    -- A custom `on_attach` function to be run after the default `on_attach` function
+    -- takes two parameters `client` and `bufnr`  (`:h lsp-attach`)
+    on_attach = function(client, bufnr)
+      -- this would disable semanticTokensProvider for all clients
+      -- client.server_capabilities.semanticTokensProvider = nil
+    end,
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/astroui.lua
+++ b/home-manager/config/nvim/lua/plugins/astroui.lua
@@ -1,0 +1,39 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- AstroUI provides the basis for configuring the AstroNvim User Interface
+-- Configuration documentation can be found with `:h astroui`
+-- NOTE: We highly recommend setting up the Lua Language Server (`:LspInstall lua_ls`)
+--       as this provides autocomplete and documentation while editing
+
+---@type LazySpec
+return {
+  "AstroNvim/astroui",
+  ---@type AstroUIOpts
+  opts = {
+    -- change colorscheme
+    colorscheme = "astrodark",
+    -- AstroUI allows you to easily modify highlight groups easily for any and all colorschemes
+    highlights = {
+      init = { -- this table overrides highlights in all themes
+        -- Normal = { bg = "#000000" },
+      },
+      astrodark = { -- a table of overrides/changes when applying the astrotheme theme
+        -- Normal = { bg = "#000000" },
+      },
+    },
+    -- Icons can be configured throughout the interface
+    icons = {
+      -- configure the loading of the lsp in the status line
+      LSPLoading1 = "⠋",
+      LSPLoading2 = "⠙",
+      LSPLoading3 = "⠹",
+      LSPLoading4 = "⠸",
+      LSPLoading5 = "⠼",
+      LSPLoading6 = "⠴",
+      LSPLoading7 = "⠦",
+      LSPLoading8 = "⠧",
+      LSPLoading9 = "⠇",
+      LSPLoading10 = "⠏",
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/formatter.lua
+++ b/home-manager/config/nvim/lua/plugins/formatter.lua
@@ -1,0 +1,18 @@
+return {
+  "stevearc/conform.nvim",
+  opts = {
+    formatters_by_ft = {
+      html = { "prettier" },
+    },
+    formatters = {
+      prettier = {
+        prepend_args = {
+          "--tab-width",
+          "2",
+          "--use-tabs",
+          "false",
+        },
+      },
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/mason-lspconfig.lua
+++ b/home-manager/config/nvim/lua/plugins/mason-lspconfig.lua
@@ -1,0 +1,6 @@
+return {
+  {
+    "williamboman/mason-lspconfig.nvim",
+    enabled = false,
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/mason.lua
+++ b/home-manager/config/nvim/lua/plugins/mason.lua
@@ -1,0 +1,28 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- Customize Mason
+
+---@type LazySpec
+return {
+  -- use mason-tool-installer for automatically installing Mason packages
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    -- overrides `require("mason-tool-installer").setup(...)`
+    opts = {
+      -- Make sure to use the names found in `:Mason`
+      ensure_installed = {
+        -- install language servers
+        "lua-language-server",
+
+        -- install formatters
+        "stylua",
+
+        -- install debuggers
+        "debugpy",
+
+        -- install any other package
+        "tree-sitter-cli",
+      },
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/none-ls.lua
+++ b/home-manager/config/nvim/lua/plugins/none-ls.lua
@@ -1,0 +1,7 @@
+return {
+  "nvimtools/none-ls.nvim",
+  opts = function(_, opts)
+    opts.sources = require("astrocore").list_insert_unique(opts.sources, {
+    })
+  end,
+}

--- a/home-manager/config/nvim/lua/plugins/smear-cursor.lua
+++ b/home-manager/config/nvim/lua/plugins/smear-cursor.lua
@@ -1,0 +1,23 @@
+return {
+  "sphamba/smear-cursor.nvim",
+
+  opts = {
+    -- Smear cursor when switching buffers or windows.
+    smear_between_buffers = true,
+
+    -- Smear cursor when moving within line or to neighbor lines.
+    -- Use `min_horizontal_distance_smear` and `min_vertical_distance_smear` for finer control
+    smear_between_neighbor_lines = true,
+
+    -- Draw the smear in buffer space instead of screen space when scrolling
+    scroll_buffer_space = true,
+
+    -- Set to `true` if your font supports legacy computing symbols (block unicode symbols).
+    -- Smears and particles will look a lot less blocky.
+    legacy_computing_symbols_support = false,
+
+    -- Smear cursor in insert mode.
+    -- See also `vertical_bar_cursor_insert_mode` and `distance_stop_animating_vertical_bar`.
+    smear_insert_mode = true,
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/telescope.lua
+++ b/home-manager/config/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,8 @@
+return {
+  {
+    "nvim-telescope/telescope.nvim",
+    keys = {
+      { "<leader>fw", "<cmd>Telescope live_grep<cr>", desc = "Find word (ripgrep)" },
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/treesitter.lua
+++ b/home-manager/config/nvim/lua/plugins/treesitter.lua
@@ -2,9 +2,9 @@ return {
   "AstroNvim/astrocore",
   opts = {
     treesitter = {
-      highlight = true, -- enable/disable treesitter based highlighting
-      indent = true, -- enable/disable treesitter based indentation
-      auto_install = true, -- enable/disable automatic installation of detected languages
+      highlight = true,
+      indent = true,
+      auto_install = true,
       ensure_installed = {
         "lua",
         "vim",

--- a/home-manager/config/nvim/lua/plugins/treesitter.lua
+++ b/home-manager/config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,17 @@
+return {
+  "AstroNvim/astrocore",
+  opts = {
+    treesitter = {
+      highlight = true, -- enable/disable treesitter based highlighting
+      indent = true, -- enable/disable treesitter based indentation
+      auto_install = true, -- enable/disable automatic installation of detected languages
+      ensure_installed = {
+        "lua",
+        "vim",
+        "html",
+        "go",
+        "gotmpl",
+      },
+    },
+  },
+}

--- a/home-manager/config/nvim/lua/plugins/user.lua
+++ b/home-manager/config/nvim/lua/plugins/user.lua
@@ -1,0 +1,90 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- You can also add or configure plugins by creating files in this `plugins/` folder
+-- PLEASE REMOVE THE EXAMPLES YOU HAVE NO INTEREST IN BEFORE ENABLING THIS FILE
+-- Here are some examples:
+
+---@type LazySpec
+return {
+
+  -- == Examples of Adding Plugins ==
+
+  "andweeb/presence.nvim",
+  {
+    "ray-x/lsp_signature.nvim",
+    event = "BufRead",
+    config = function() require("lsp_signature").setup() end,
+  },
+
+  -- == Examples of Overriding Plugins ==
+
+  -- customize dashboard options
+  {
+    "folke/snacks.nvim",
+    opts = {
+      dashboard = {
+        preset = {
+          header = table.concat({
+            " █████  ███████ ████████ ██████   ██████ ",
+            "██   ██ ██         ██    ██   ██ ██    ██",
+            "███████ ███████    ██    ██████  ██    ██",
+            "██   ██      ██    ██    ██   ██ ██    ██",
+            "██   ██ ███████    ██    ██   ██  ██████ ",
+            "",
+            "███    ██ ██    ██ ██ ███    ███",
+            "████   ██ ██    ██ ██ ████  ████",
+            "██ ██  ██ ██    ██ ██ ██ ████ ██",
+            "██  ██ ██  ██  ██  ██ ██  ██  ██",
+            "██   ████   ████   ██ ██      ██",
+          }, "\n"),
+        },
+      },
+    },
+  },
+
+  -- You can disable default plugins as follows:
+  { "max397574/better-escape.nvim", enabled = false },
+
+  -- You can also easily customize additional setup of plugins that is outside of the plugin's setup call
+  {
+    "L3MON4D3/LuaSnip",
+    config = function(plugin, opts)
+      -- add more custom luasnip configuration such as filetype extend or custom snippets
+      local luasnip = require "luasnip"
+      luasnip.filetype_extend("javascript", { "javascriptreact" })
+
+      -- include the default astronvim config that calls the setup call
+      require "astronvim.plugins.configs.luasnip"(plugin, opts)
+    end,
+  },
+
+  {
+    "windwp/nvim-autopairs",
+    config = function(plugin, opts)
+      require "astronvim.plugins.configs.nvim-autopairs"(plugin, opts) -- include the default astronvim config that calls the setup call
+      -- add more custom autopairs configuration such as custom rules
+      local npairs = require "nvim-autopairs"
+      local Rule = require "nvim-autopairs.rule"
+      local cond = require "nvim-autopairs.conds"
+      npairs.add_rules(
+        {
+          Rule("$", "$", { "tex", "latex" })
+            -- don't add a pair if the next character is %
+            :with_pair(cond.not_after_regex "%%")
+            -- don't add a pair if  the previous character is xxx
+            :with_pair(
+              cond.not_before_regex("xxx", 3)
+            )
+            -- don't move right when repeat character
+            :with_move(cond.none())
+            -- don't delete if the next character is xx
+            :with_del(cond.not_after_regex "xx")
+            -- disable adding a newline when you press <cr>
+            :with_cr(cond.none()),
+        },
+        -- disable for .vim files, but it work for another filetypes
+        Rule("a", "a", "-vim")
+      )
+    end,
+  },
+}

--- a/home-manager/config/nvim/lua/polish.lua
+++ b/home-manager/config/nvim/lua/polish.lua
@@ -1,0 +1,5 @@
+if true then return end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
+-- This will run last in the setup process.
+-- This is just pure lua so anything that doesn't
+-- fit in the normal config locations above can go here

--- a/home-manager/config/nvim/neovim.yml
+++ b/home-manager/config/nvim/neovim.yml
@@ -1,0 +1,6 @@
+---
+base: lua51
+
+globals:
+  vim:
+    any: true

--- a/home-manager/config/nvim/selene.toml
+++ b/home-manager/config/nvim/selene.toml
@@ -1,0 +1,8 @@
+std = "neovim"
+
+[rules]
+global_usage = "allow"
+if_same_then_else = "allow"
+incorrect_standard_library_use = "allow"
+mixed_table = "allow"
+multiple_statements = "allow"

--- a/home-manager/modules/core/cli.nix
+++ b/home-manager/modules/core/cli.nix
@@ -33,7 +33,7 @@
       libiconv
       mtr
       ncdu
-      neovim
+      pkgs-unstable.neovim
       nvd
       nmap
       pkgs-unstable.gh

--- a/home-manager/modules/programs/default.nix
+++ b/home-manager/modules/programs/default.nix
@@ -10,5 +10,6 @@
     ./tmux.nix
     ./pi.nix
     ./claude.nix
+    ./neovim.nix
   ];
 }

--- a/home-manager/modules/programs/neovim.nix
+++ b/home-manager/modules/programs/neovim.nix
@@ -1,0 +1,6 @@
+_: {
+  xdg.configFile."nvim" = {
+    source = ../../config/nvim;
+    recursive = true;
+  };
+}


### PR DESCRIPTION
## Summary

Adds AstroVim v6 as a Home Manager-managed neovim configuration.

## Changes

- **New module** `home-manager/modules/programs/neovim.nix` - deploys nvim config via `xdg.configFile`
- **AstroVim v6 config** under `home-manager/config/nvim/` - fresh v6 template with custom plugins
- **Lockfile** stored at `~/.local/state/nvim/lazy-lock.json` - never tracked by git
- **neovim** switched to unstable channel; ripgrep and fd already managed globally in `cli.nix`

## Custom plugins

- `formatter.lua` - prettier for HTML
- `smear-cursor.lua` - cursor animation
- `telescope.lua` - custom keybinding
- `aerial.lua` - disabled (nvim 0.12 compat)
- `mason-lspconfig.lua` - disabled (nvim 0.12 compat)
- `options.lua`, `config/autocmds.lua` - custom vim settings