### PR TITLE
docs(git-ci): add PR/MR description template to pi and opencode prompts

### DIFF
--- a/home-manager/config/opencode/skills/git-ci/SKILL.md
+++ b/home-manager/config/opencode/skills/git-ci/SKILL.md
@@ -43,7 +43,28 @@ Finally, ask the user to review the changes. If they approve, follow this workfl
 1. Create a new branch from the current branch (do NOT checkout master/main).
 2. Commit the changes to the new branch.
 3. Push the branch to the remote repository.
-4. Create a Pull Request (GitHub) or Merge Request (GitLab) for the branch.
+4. Create a Pull Request (GitHub, gh) or Merge Request (GitLab, glab) for the branch.
+   Use the following PR/MR description template:
+
+   ```
+   ## Summary
+
+   1-3 sentences explaining what this PR does and why
+
+   - Bulleted list of changes made (same as the commit body bullet points)
+   - Group/sort related changes together
+   - Be specific about what was added, modified, or removed
+
+   ## Notes for reviewers
+
+   Any context reviewers need (breaking changes, deployment notes, follow-up tasks).
+
+   ## Files changed
+
+   - `<file-path>`
+   - `<file-path>`
+   ```
+
 5. The user will review the PR/MR on GitHub/GitLab and merge it manually.
 
 Important rules:

--- a/home-manager/config/pi/prompts/git-ci.md
+++ b/home-manager/config/pi/prompts/git-ci.md
@@ -42,10 +42,32 @@ Finally, ask the user to review the changes. If they approve, follow this workfl
 1. Create a new branch from the current branch (do NOT checkout master/main).
 2. Commit the changes to the new branch.
 3. Push the branch to the remote repository.
-4. Create a Pull Request (GitHub) or Merge Request (GitLab) for the branch.
+4. Create a Pull Request (GitHub, gh) or Merge Request (GitLab, glab) for the branch.
+   Use the following PR/MR description template:
+
+   ```
+   ## Summary
+
+   1-3 sentences explaining what this PR does and why
+
+   - Bulleted list of changes made (same as the commit body bullet points)
+   - Group/sort related changes together
+   - Be specific about what was added, modified, or removed
+
+   ## Notes for reviewers
+
+   Any context reviewers need (breaking changes, deployment notes, follow-up tasks).
+
+   ## Files changed
+
+   - `<file-path>`
+   - `<file-path>`
+   ```
+
 5. The user will review the PR/MR on GitHub/GitLab and merge it manually.
 
 Important rules:
+
 - NEVER checkout `master` (or `main`) and merge locally.
 - Respect protected branches (e.g., `master`, `main`). Do not push directly to them.
 - All changes must go through a feature/fix branch and a PR/MR.


### PR DESCRIPTION
## Summary

Add a structured PR/MR description template to both pi and opencode git-ci prompts so agents generate consistent PR descriptions.

- Add structured template with Summary, Notes, and Files changed sections
- Add inline placeholder instructions for each section
- Add gh/glab CLI references in both prompt templates

## Notes for reviewers

No breaking changes. Templates are used when the agent creates PRs/MRs via step 4 of the commit workflow.

## Files changed

- `home-manager/config/pi/prompts/git-ci.md`
- `home-manager/config/opencode/skills/git-ci/SKILL.md`