### PR TITLE
refactor(opencode): convert skills to flat slash commands

### DIFF
--- a/home-manager/config/opencode/commands/audit-me.md
+++ b/home-manager/config/opencode/commands/audit-me.md
@@ -1,5 +1,4 @@
 ---
-name: audit-me
 description: "Review and audit a document section-by-section, challenging correctness, necessity, and alternatives. Use when user wants a rigorous document audit or design review."
 ---
 

--- a/home-manager/config/opencode/commands/git-ci.md
+++ b/home-manager/config/opencode/commands/git-ci.md
@@ -1,5 +1,4 @@
 ---
-name: git-ci
 description: Generate a commit message from staged changes
 ---
 

--- a/home-manager/config/opencode/commands/grill-me.md
+++ b/home-manager/config/opencode/commands/grill-me.md
@@ -1,5 +1,4 @@
 ---
-name: grill-me
 description: "Interview the user relentlessly until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, spec, design, or any document."
 ---
 

--- a/home-manager/config/opencode/commands/handoff.md
+++ b/home-manager/config/opencode/commands/handoff.md
@@ -1,5 +1,4 @@
 ---
-name: handoff
 description: Compact the current conversation into a handoff document for another agent to pick up
 ---
 

--- a/home-manager/config/opencode/commands/review.md
+++ b/home-manager/config/opencode/commands/review.md
@@ -1,5 +1,4 @@
 ---
-name: review
 description: Review staged git changes for bugs, correctness, and best practices
 ---
 

--- a/home-manager/config/opencode/commands/spec-quick.md
+++ b/home-manager/config/opencode/commands/spec-quick.md
@@ -1,5 +1,4 @@
 ---
-name: spec-quick
 description: "Lightweight spec-driven workflow for small-scope tasks: quick plan → execute → verify"
 ---
 
@@ -132,7 +131,7 @@ Once the plan is confirmed:
 3. **Verify**: Run the verification steps. Show evidence.
 4. **Review**: Present the completed work.
 5. **Git Checkpoint** (MANDATORY - rollback safety net):
-   - After confirmation, use the `git-ci` skill (load via `skill({ name: "git-ci" })`) to:
+   - After confirmation, run the `/git-ci` command to:
      1. Stage all changes
      2. Generate a commit message and branch name
      3. Create a new branch, commit, and push
@@ -146,7 +145,7 @@ Once the plan is confirmed:
 
 For tasks that are inherently risky (auth, payments, data migrations, concurrency, shared infrastructure) or span 3+ files with non-trivial logic, suggest an independent review after Step 4 and before Git Checkpoint:
 
-> "This task is complex enough to warrant an independent review. Load the `review` skill via `skill({ name: "review" })` to review the staged changes."
+> "This task is complex enough to warrant an independent review. Run the `/review` command to review the staged changes."
 
 If declined, proceed with Git Checkpoint.
 

--- a/home-manager/config/opencode/commands/spec-workflow.md
+++ b/home-manager/config/opencode/commands/spec-workflow.md
@@ -1,5 +1,4 @@
 ---
-name: spec-workflow
 description: "Spec-driven development: research → spec → implementation plan → phased execution with pair review"
 ---
 
@@ -196,7 +195,7 @@ For each phase, in order:
 4. **Verify**: Run the verification steps against the phase's Objective. Show evidence.
 5. **Pair Review**: Present the completed phase for review.
 6. **Git Checkpoint** (MANDATORY - rollback safety net):
-   - After confirmation, use the `git-ci` skill (load via `skill({ name: "git-ci" })`) to:
+   - After confirmation, run the `/git-ci` command to:
      1. Stage all changes
      2. Generate a commit message and branch name (do NOT prefix with phase labels)
      3. Create a new branch, commit, and push
@@ -212,7 +211,7 @@ For each phase, in order:
 
 For phases that are inherently risky (auth, payments, data migrations, concurrency, shared infrastructure) or span 5+ files with non-trivial logic, suggest an independent review after Pair Review and before Git Checkpoint:
 
-> "Phase N is complex enough to warrant an independent review. Load the `review` skill via `skill({ name: "review" })` to review the staged changes. The reviewer should use a different model if possible."
+> "Phase N is complex enough to warrant an independent review. Run the `/review` command to review the staged changes. The reviewer should use a different model if possible."
 
 If declined, proceed with Git Checkpoint.
 

--- a/home-manager/modules/programs/opencode.nix
+++ b/home-manager/modules/programs/opencode.nix
@@ -50,6 +50,6 @@ in {
   home.file = {
     ".config/opencode/opencode.json".source = ../../config/opencode/opencode.json;
     ".config/opencode/APPEND_SYSTEM.md".source = ../../config/opencode/APPEND_SYSTEM.md;
-    ".config/opencode/skills".source = ../../config/opencode/skills;
+    ".config/opencode/commands".source = ../../config/opencode/commands;
   };
 }


### PR DESCRIPTION
## Summary

Convert opencode skills from nested `skills/<name>/SKILL.md` structure to opencode native flat `commands/<name>.md` slash commands. Commands use YAML frontmatter and are invoked via `/` prefix instead of `skill()` function calls.

- Replace nested skills/*/SKILL.md with flat commands/*.md using YAML frontmatter
- Update skill() references to /command invocations in spec-workflow and spec-quick
- Update opencode.nix symlink from skills to commands directory

## Notes for reviewers

No breaking changes for pi prompts (those remain separate). OpenCode commands are auto-discovered from the `commands/` directory.

## Files changed

- `home-manager/config/opencode/commands/*.md` (7 new)
- `home-manager/config/opencode/skills/*/SKILL.md` (7 deleted)
- `home-manager/modules/programs/opencode.nix`