### PR TITLE
feat: add flux-markdown macOS app package

### DIFF
--- a/home-manager/modules/core/gui.nix
+++ b/home-manager/modules/core/gui.nix
@@ -12,5 +12,6 @@
     ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
       pkgs-unstable.betterdisplay
       pkgs-unstable.karabiner-elements
+      flux-markdown
     ]));
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-# Custom packages: kage, kcctl, yomi
+# Custom packages: kage, kcctl, yomi, flux-markdown
 # Built via 'nix build .#<name>' or accessed as pkgs.<name> in home-manager
 # via the overlay in ../overlays
 {
@@ -14,4 +14,6 @@
   yomi = pkgs.callPackage ./yomi.nix {
     go = pkgsUnstable.go_1_26;
   };
+
+  flux-markdown = pkgs.callPackage ./flux-markdown.nix {};
 }

--- a/pkgs/flux-markdown.nix
+++ b/pkgs/flux-markdown.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "flux-markdown";
+  version = "1.34.464";
+
+  src = fetchurl {
+    url = "https://github.com/xykong/flux-markdown/releases/download/v${version}/FluxMarkdown.dmg";
+    hash = "sha256-YFyQIhNa9OFW4z2IQqyeaPUHcgK18OBUCQghXTzQH6E=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r FluxMarkdown.app $out/Applications/
+  '';
+
+  meta = with lib; {
+    description = "A modern Markdown editor for macOS";
+    homepage = "https://github.com/xykong/flux-markdown";
+    license = licenses.unfree;
+    mainProgram = "FluxMarkdown";
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ ];
+  };
+}


### PR DESCRIPTION
## Summary

Package flux-markdown (v1.34.464), a modern Markdown editor for macOS, from its GitHub releases DMG and install it on darwin hosts.

- Add pkgs/flux-markdown.nix derivation (v1.34.464) from GitHub releases DMG
- Register flux-markdown in pkgs/default.nix overlay
- Install flux-markdown on darwin hosts via gui.nix

## Notes for reviewers

Uses `undmg` to extract the `.dmg` and copies the `.app` bundle to `$out/Applications/`. The package is macOS-only (`platforms.darwin`).

## Files changed

- `pkgs/flux-markdown.nix`
- `pkgs/default.nix`
- `home-manager/modules/core/gui.nix`